### PR TITLE
added basic parsing error reporting

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -45,7 +45,7 @@ impl CompilationUnit {
         //this can be improved
         for (line_nr, line_break_offset) in self.new_lines.iter().enumerate() {
             if line_break_offset > offset {
-                return line_nr + 1;
+                return line_nr;
             }
         }
         self.new_lines.len()

--- a/src/parser/control/mod.rs
+++ b/src/parser/control/mod.rs
@@ -31,13 +31,14 @@ fn parse_if_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
 
     
     let mut conditional_blocks = vec![];
-
+    
     while lexer.token == KeywordElseIf || lexer.token == KeywordIf{
+        let line_nr = lexer.get_current_line_nr();
         lexer.advance();//If//ElseIf
         let condition = parse_expression(lexer);
         expect!(KeywordThen, lexer);
         lexer.advance();
-        let body = parse_body(lexer, &end_of_body);
+        let body = parse_body(lexer, line_nr, &end_of_body);
 
         let condition_block = ConditionalBlock {
             condition: Box::new(condition?),
@@ -50,8 +51,9 @@ fn parse_if_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     let mut else_block = Vec::new();
 
     if lexer.token == KeywordElse {
+        let line_nr = lexer.get_current_line_nr();
         lexer.advance(); // else
-        else_block.append(&mut parse_body(lexer, &|it| *it == KeywordEndIf)?)
+        else_block.append(&mut parse_body(lexer, line_nr, &|it| *it == KeywordEndIf)?)
     }
 
     let end = lexer.range().end;
@@ -82,10 +84,12 @@ fn parse_for_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     };
     
     expect!(KeywordDo, lexer); // DO
+    let line_nr = lexer.get_current_line_nr();
     lexer.advance();
 
     let body = parse_body(
-                    lexer, 
+                    lexer,
+                    line_nr,
                     &|t: &lexer::Token| *t == KeywordEndFor);
 
     let end = lexer.range().end;
@@ -96,6 +100,7 @@ fn parse_for_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
 
 fn parse_while_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     let start = lexer.range().start;
+    let line_nr = lexer.get_current_line_nr();
     lexer.advance(); //WHILE
 
     let condition = Box::new(parse_expression(lexer)?);
@@ -105,6 +110,7 @@ fn parse_while_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     
     let body = parse_body(
                     lexer,
+                    line_nr,
                     &|t: &lexer::Token| *t == KeywordEndWhile)?;
 
     let end = lexer.range().end;
@@ -115,10 +121,12 @@ fn parse_while_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
 
 fn parse_repeat_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     let start = lexer.range().start;
+    let line_nr = lexer.get_current_line_nr();
     lexer.advance(); //REPEAT
     
     let body = parse_body(
         lexer,
+        line_nr,
         &|t: &lexer::Token| *t == KeywordUntil)?; //UNTIL
     lexer.advance();
 
@@ -134,22 +142,23 @@ fn parse_repeat_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
 fn parse_case_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     let start = lexer.range().start;
     lexer.advance(); // CASE
-
+    
     let selector = Box::new(parse_expression(lexer)?);
-
+    
     expect!(KeywordOf, lexer); // OF
     lexer.advance();
-
+    
     let mut case_blocks = Vec::new();
     if lexer.token != KeywordEndCase && lexer.token != KeywordElse {
         let mut condition = Some(parse_expression(lexer)?);
+        let case_line_nr = lexer.get_current_line_nr();
         expect!(KeywordColon, lexer); // :
         lexer.advance();
         
         
         loop {
             
-            let (body, next_condition) = parse_case_body_with_condition( condition.unwrap(), lexer)?;
+            let (body, next_condition) = parse_case_body_with_condition( condition.unwrap(), lexer, case_line_nr)?;
             condition = next_condition;
             case_blocks.push(body);
             
@@ -162,8 +171,9 @@ fn parse_case_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     let mut else_block = Vec::new();
 
     if lexer.token == KeywordElse {
+        let line_nr = lexer.get_current_line_nr();
         lexer.advance(); // else
-        else_block.append(&mut parse_body(lexer, &|it| *it == KeywordEndCase)?)
+        else_block.append(&mut parse_body(lexer, line_nr, &|it| *it == KeywordEndCase)?)
     }
     let end = lexer.range().end;
     lexer.advance();
@@ -175,15 +185,16 @@ fn parse_case_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
  * returns a case-body (limited by either END_CASE, ELSE or another case-condition <xxx> : ) combined in a tuple 
  * with an optional following case-condition (the condition of the next case-body)
  */
-fn parse_case_body_with_condition(condition: Statement, lexer: &mut RustyLexer) -> Result<(ConditionalBlock, Option<Statement>), String> {
-    let mut body = parse_body(lexer, &|t: &lexer::Token| *t == KeywordEndCase || *t == KeywordColon || *t == KeywordElse )?;
+fn parse_case_body_with_condition(condition: Statement, lexer: &mut RustyLexer, start_of_case : usize) -> Result<(ConditionalBlock, Option<Statement>), String> {
+    let mut body = parse_body(lexer, start_of_case, &|t: &lexer::Token| *t == KeywordEndCase || *t == KeywordColon || *t == KeywordElse )?;
     if lexer.token == KeywordColon {
+        let colon_line_nr = lexer.get_current_line_nr();
         lexer.advance();
         // the block was ended with a new case-condition (e.g. '2:')
         // so we add the block and return the next block's condition
         // because we already parsed it 
         if body.is_empty() {
-            return Err("Unexpected ':' - no case-condition could be found.".to_string());
+            return Err(format!("unexpected ':' at line {:} - no case-condition could be found", colon_line_nr));
         }
 
         //


### PR DESCRIPTION
including line-number, offset of the problem and the
text that actually caused the problem. 

e.g.
```expected KeywordEndVar, but found 'END_PROGRAM' [KeywordEndProgram] at line: 1 offset: 16..27```