### PR TITLE
Bugfix #111 functions out of order

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -104,8 +104,16 @@ impl<'ctx> CodeGen<'ctx> {
 
         //generate all pou's
         let mut pou_generator = PouGenerator::new(&llvm, &mut self.index);
+        //Generate the POU stubs in the first go to make sure they can be referenced.
         for unit in &unit.units {
-            pou_generator.generate_pou(unit, &self.module)?;
+            pou_generator.generate_pou_stub(unit, &self.module)?;
+        }
+
+        for unit in &unit.units {
+            //Don't generate external functions
+            if unit.linkage != LinkageType::External {
+                pou_generator.generate_pou(unit)?;
+            }
         }
 
         // TODO this is not needed

--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -2038,6 +2038,37 @@ continue:                                         ; preds = %output
 }
 
 #[test]
+fn program_called_before_decalaration() {
+    codegen!(
+        "
+        PROGRAM foo 
+          bar();
+        END_PROGRAM
+
+        PROGRAM bar 
+        END_PROGRAM
+        "
+    );
+    //Expecting no errors
+}
+
+#[test]
+fn function_called_before_decalaration() {
+    codegen!(
+        "
+        FUNCTION foo : INT
+          foo := bar();
+        END_FUNCTION
+
+        FUNCTION bar : INT
+            bar := 7;
+        END_FUNCTION
+        "
+    );
+    //Expecting no errors
+}
+
+#[test]
 fn function_called_when_shadowed() {
   let result = codegen!(
         "

--- a/tests/correctness/functions.rs
+++ b/tests/correctness/functions.rs
@@ -242,6 +242,34 @@ fn program_instances_save_state_per() {
         assert_eq!(interface.f.i,6);
 }
 
+#[test]
+fn functions_can_be_called_out_of_order() {
+    struct MainType {
+        f : i16,
+    }
+    let function = r#"
+
+    FUNCTION foo : INT
+      foo := bar();
+    END_FUNCTION
+
+    FUNCTION bar : INT
+        bar := 7;
+    END_FUNCTION
+
+    PROGRAM main
+        VAR 
+            r : INT;
+        END_VAR 
+        r:= foo();
+    END_PROGRAM
+    "#;
+    
+    let mut interface = MainType{ f: 0 };
+    let (_, _) = compile_and_run(function.to_string(), &mut interface);
+
+    assert_eq!(7, interface.f);
+}
 
 #[test]
 fn function_block_instances_save_state_per_instance_2() {


### PR DESCRIPTION
Split the generation of POUs

Allow the POUs to all be indexed before they get generated
This allows POUs to be called out of order

Fixes #111
