### PR TITLE
Ignore Carriage return when lexing (Windows Support)

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -108,6 +108,7 @@ pub enum Token {
     #[regex(r"\(\*", |lex| parse_comments(lex))]
     #[regex(r"/\*", |lex| parse_comments(lex))]
     #[regex(r"//.*", logos::skip)]
+    #[regex(r"(?m)\r", logos::skip)]
     Error,
 
     

--- a/src/lexer/tests/lexer_tests.rs
+++ b/src/lexer/tests/lexer_tests.rs
@@ -11,6 +11,14 @@ fn generic_properties() {
 }
 
 #[test]
+fn windows_and_linux_line_separators_ignored() {
+    let mut lexer = lex("PROGRAM\r\nEND_PROGRAM");
+    assert_eq!(lexer.token, KeywordProgram, "Token : {}", lexer.slice());
+    lexer.advance();
+    assert_eq!(lexer.token, KeywordEndProgram, "Token : {}", lexer.slice());
+}
+
+#[test]
 fn comments_are_ignored_by_the_lexer() {
     let mut lexer = lex(r"
         PROGRAM (* Some Content *) END_PROGRAM 


### PR DESCRIPTION
\r is now correctly ignored by the lexer.
It seems that \n is already ignored, but it is now covered in the test.