### PR TITLE
add support for struct instance initialization (fix #131)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust:buster
-RUN useradd -ms /bin/bash vscode
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
 
 ARG LLVM_VER=11
 RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-$LLVM_VER  main" >> /etc/apt/sources.list

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Structured text compiler written in Rust
 - :heavy_check_mark: Alias types
 - :x: Sub-ranges types
 - :x: Sized String types
-- :x: Initial values
+- :heavy_check_mark: Initial values
 
 ## Declarations
 - :heavy_check_mark: VAR

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -99,7 +99,11 @@ impl<'ctx> CodeGen<'ctx> {
 
         //index all pou's
         for unit in &unit.units {
-            pou_generator::index_pou(unit.name.as_str(), self.context, self.index);
+            let variable_names : Vec<String> = unit.variable_blocks.iter()
+                    .flat_map(|it| &it.variables)
+                    .map(|it| it.name.to_string())
+                    .collect();
+            pou_generator::index_pou(unit.name.as_str(), self.context, self.index, variable_names);
         }
 
         //generate all pou's

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -18,7 +18,8 @@ use super::{expression_generator::ExpressionCodeGenerator, llvm::LLVM, struct_ge
 pub fn generate_data_type_stubs<'a>(llvm: &LLVM<'a>, index: &mut Index<'a>, data_types: &Vec<UserTypeDeclaration>) -> Result<(), CompileError>{
     for user_type in data_types {
         match &user_type.data_type {
-            DataType::StructType { name, variables: _ } => {
+            DataType::StructType { name, variables } => {
+                let member_names :Vec<String> = variables.iter().map(|it| it.name.to_string()).collect();
                 index.associate_type(
                     name.as_ref().unwrap().as_str(),
                     DataTypeInformation::Struct {
@@ -26,6 +27,7 @@ pub fn generate_data_type_stubs<'a>(llvm: &LLVM<'a>, index: &mut Index<'a>, data
                         generated_type: llvm
                             .create_struct_stub(name.as_ref().unwrap())
                             .into(),
+                        member_names
                     },
                 );
             }
@@ -101,6 +103,7 @@ pub fn generate_data_type<'a>(
                 let members: Vec<&Variable> = variables.iter().collect();
                 let (_, initial_value) = struct_generator.generate_struct_type(&members, name)?;
                 index.associate_type_initial_value(name, initial_value);
+                
             }
             DataType::EnumType { name: _, elements } => {
                 // generate a global variable for every enum element

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -218,11 +218,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
             },
             Statement::QualifiedReference { .. } => {
                 let loaded_value = self.generate_load_for(operator);
-                if let Ok(TypeAndPointer{type_entry, ptr_value}) = loaded_value {
-                    Ok((ptr_value, type_entry))
-                } else {
-                    Err(CompileError::CodeGenError{ message: format!("cannot generate call statement for {:?}", operator), location: operator.get_location().clone() })
-                }
+                loaded_value.map(|TypeAndPointer{type_entry, ptr_value}| Ok((ptr_value, type_entry)))?
             },
             _ => Err(CompileError::CodeGenError{ message: format!("cannot generate call statement for {:?}", operator), location: operator.get_location().clone() }),
         };

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -215,7 +215,15 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
 
                 let index_entry = self.index.get_type(call_name.unwrap())?;
                 Ok((callable_reference, index_entry))
-            }
+            },
+            Statement::QualifiedReference { .. } => {
+                let loaded_value = self.generate_load_for(operator);
+                if let Ok(TypeAndPointer{type_entry, ptr_value}) = loaded_value {
+                    Ok((ptr_value, type_entry))
+                } else {
+                    Err(CompileError::CodeGenError{ message: format!("cannot generate call statement for {:?}", operator), location: operator.get_location().clone() })
+                }
+            },
             _ => Err(CompileError::CodeGenError{ message: format!("cannot generate call statement for {:?}", operator), location: operator.get_location().clone() }),
         };
 

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -16,7 +16,7 @@ pub struct PouGenerator<'a, 'b> {
 }
 
 /// creates an opaque-struct type for the pou and registers at the given index
-pub fn index_pou<'a>(pou_name: &str, context: &'a Context, index: &mut Index<'a>) {
+pub fn index_pou<'a>(pou_name: &str, context: &'a Context, index: &mut Index<'a>, variable_names: Vec<String>) {
     let struct_name = format!("{}_interface", pou_name);
     let struct_type = context.opaque_struct_type(struct_name.as_str());
     index.associate_type(
@@ -24,6 +24,7 @@ pub fn index_pou<'a>(pou_name: &str, context: &'a Context, index: &mut Index<'a>
         DataTypeInformation::Struct {
             name: struct_name,
             generated_type: struct_type.into(),
+            member_names: variable_names,
         },
     );
 }

--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -1,6 +1,6 @@
 /// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
-use crate::{codegen, generate_with_empty_program, lexer };
+use crate::{codegen, codegen_wihout_unwrap, compile_error::CompileError, generate_with_empty_program, lexer};
 use crate::parser;
 use crate::index::Index;
 use inkwell::context::Context;
@@ -3167,4 +3167,135 @@ source_filename = "main"
 "#;
  
   assert_eq!(result, expected); 
+}
+
+#[test]
+fn initial_values_in_struct_variable_using_multiplied_statement(){
+    let result = codegen!(
+         "
+        TYPE MyStruct: STRUCT
+          a: DINT;
+          b: DINT;
+        END_STRUCT
+        END_TYPE
+
+         VAR_GLOBAL 
+           a : MyStruct  := (a:=3, b:=5); 
+         END_VAR
+         "
+     );
+
+  let expected = r#"; ModuleID = 'main'
+source_filename = "main"
+
+%MyStruct = type { i32, i32 }
+
+@a = global %MyStruct { i32 3, i32 5 }
+"#;
+ 
+  assert_eq!(result, expected); 
+}
+
+#[test]
+fn complex_initial_values_in_struct_variable_using_multiplied_statement(){
+    let result = codegen!(
+         "
+        TYPE MyPoint: STRUCT
+          x: DINT;
+          y: DINT;
+        END_STRUCT
+        END_TYPE
+ 
+        TYPE MyStruct: STRUCT
+          point: MyPoint;
+          my_array: ARRAY[0..3] OF INT;
+          f : DINT;
+        END_STRUCT
+        END_TYPE
+
+        VAR_GLOBAL 
+          a : MyStruct  := (
+              point := (x := 1, y:= 2),
+              my_array := [0,1,2,3],
+              f := 7
+            ); 
+        END_VAR
+        "
+     );
+
+  let expected = r#"; ModuleID = 'main'
+source_filename = "main"
+
+%MyStruct = type { %MyPoint, [4 x i16], i32 }
+%MyPoint = type { i32, i32 }
+
+@a = global %MyStruct { %MyPoint { i32 1, i32 2 }, [4 x i16] [i16 0, i16 1, i16 2, i16 3], i32 7 }
+"#;
+ 
+  assert_eq!(result, expected); 
+}
+
+#[test]
+fn struct_with_one_field_can_be_initialized(){
+    let result = codegen!(
+         "
+        TYPE MyPoint: STRUCT
+          x: DINT;
+        END_STRUCT
+        END_TYPE
+ 
+        VAR_GLOBAL 
+          a : MyPoint := ( x := 7);
+        END_VAR
+        "
+     );
+
+  let expected = r#"; ModuleID = 'main'
+source_filename = "main"
+
+%MyPoint = type { i32 }
+
+@a = global %MyPoint { i32 7 }
+"#;
+ 
+  assert_eq!(result, expected); 
+}
+
+#[test]
+fn struct_initializer_needs_assignments(){
+    let source =
+            "
+            TYPE Point: STRUCT
+              x: DINT;
+              y: DINT;
+            END_STRUCT
+            END_TYPE
+ 
+            VAR_GLOBAL
+                x : Point := (x := 1, 2);
+            END_VAR
+           ";
+    let result = codegen_wihout_unwrap!(source);
+    assert_eq!(result, Err(CompileError::codegen_error("struct literal must consist of explicit assignments in the form of member := value".to_string(), 185..186)));
+    assert_eq!(source[185..186].to_string(), "2".to_string());
+}
+
+#[test]
+fn struct_initializer_needs_to_assign_all_fields(){
+    let source =
+            "
+            TYPE Point: STRUCT
+              x: DINT;
+              y: DINT;
+              z: DINT;
+            END_STRUCT
+            END_TYPE
+ 
+            VAR_GLOBAL
+                x : Point := (x := 1, y := 2);
+            END_VAR
+           ";
+    let result = codegen_wihout_unwrap!(source);
+    assert_eq!(result, Err(CompileError::codegen_error("Expected 3 fields for Struct Point, but found 2.".to_string(), 200..214)));
+    assert_eq!(source[200..214].to_string(), "x := 1, y := 2".to_string());
 }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -1124,3 +1124,47 @@ r#"Variable {
 }"#;
     assert_eq!(expected, format!("{:#?}", x).as_str());
 }
+
+
+#[test]
+fn struct_initializer_can_be_parsed(){
+    let lexer = lexer::lex(
+            "
+            VAR_GLOBAL
+                x : Point := (x := 1, y:= 2);
+            END_VAR
+           ");
+    let (parse_result, _) = parse(lexer).unwrap();
+    let x = &parse_result.global_vars[0].variables[0];
+    let expected = 
+r#"Variable {
+    name: "x",
+    data_type: DataTypeReference {
+        referenced_type: "Point",
+    },
+    initializer: Some(
+        ExpressionList {
+            expressions: [
+                Assignment {
+                    left: Reference {
+                        name: "x",
+                    },
+                    right: LiteralInteger {
+                        value: "1",
+                    },
+                },
+                Assignment {
+                    left: Reference {
+                        name: "y",
+                    },
+                    right: LiteralInteger {
+                        value: "2",
+                    },
+                },
+            ],
+        },
+    ),
+}"#;
+    assert_eq!(expected, format!("{:#?}", x).as_str());
+}
+

--- a/tests/correctness/initial_values.rs
+++ b/tests/correctness/initial_values.rs
@@ -584,3 +584,62 @@ fn initialization_of_complex_struct_instance() {
     assert_eq!(7.89, maintype.f);
     
 }
+
+#[test]
+fn initialization_of_complex_struct_instance_using_defaults() {
+    // a.point.y and a.f are note initialized!
+    let src =
+         "
+        TYPE MyReal : REAL := 3.1415; END_TYPE
+
+        TYPE MyPoint: STRUCT
+          x: DINT;
+          y: DINT := 7;
+        END_STRUCT
+        END_TYPE
+ 
+        TYPE MyStruct: STRUCT
+          point: MyPoint;
+          my_array: ARRAY[0..3] OF INT;
+          f : MyReal;
+        END_STRUCT
+        END_TYPE
+
+        VAR_GLOBAL 
+          a : MyStruct  := (
+              point := (x := 1),
+              my_array := [0,1,2,3]
+            ); 
+        END_VAR
+
+        PROGRAM main
+            VAR
+                x : DINT;
+                y : DINT;
+                arr1 : INT;
+                arr3 : INT;
+                f : REAL;
+            END_VAR 
+
+            x := a.point.x;
+            y := a.point.y;
+            arr1 := a.my_array[1];
+            arr3 := a.my_array[3];
+            f := a.f;
+        END_PROGRAM
+        ";
+
+    let mut maintype = StructProgram {
+        x: 0, y: 0,
+        arr1 : 0, arr3 : 0,
+        f : 0.0
+    };
+
+    compile_and_run(src.to_string(), &mut maintype);
+    assert_eq!(1, maintype.x);
+    assert_eq!(7, maintype.y);
+    assert_eq!(1 , maintype.arr1);
+    assert_eq!(3, maintype.arr3);
+    assert_eq!(3.1415, maintype.f);
+    
+}

--- a/tests/correctness/initial_values.rs
+++ b/tests/correctness/initial_values.rs
@@ -517,3 +517,70 @@ fn real_initial_values_in_array_variable(){
     assert_eq!(0.000000001, maintype.r2);
 }
 
+
+#[derive(Debug)]
+#[repr(C)]
+struct StructProgram {
+    x: i32,
+    y: i32,
+    arr1: i16,
+    arr3: i16,
+    f: f32,
+}
+
+#[test]
+fn initialization_of_complex_struct_instance() {
+    let src =
+         "
+        TYPE MyPoint: STRUCT
+          x: DINT;
+          y: DINT;
+        END_STRUCT
+        END_TYPE
+ 
+        TYPE MyStruct: STRUCT
+          point: MyPoint;
+          my_array: ARRAY[0..3] OF INT;
+          f : REAL;
+        END_STRUCT
+        END_TYPE
+
+        VAR_GLOBAL 
+          a : MyStruct  := (
+              point := (x := 1, y:= 2),
+              my_array := [0,1,2,3],
+              f := 7.89
+            ); 
+        END_VAR
+
+        PROGRAM main
+            VAR
+                x : DINT;
+                y : DINT;
+                arr1 : INT;
+                arr3 : INT;
+                f : REAL;
+            END_VAR 
+
+            x := a.point.x;
+            y := a.point.y;
+            arr1 := a.my_array[1];
+            arr3 := a.my_array[3];
+            f := a.f;
+        END_PROGRAM
+        ";
+
+    let mut maintype = StructProgram {
+        x: 0, y: 0,
+        arr1 : 0, arr3 : 0,
+        f : 0.0
+    };
+
+    compile_and_run(src.to_string(), &mut maintype);
+    assert_eq!(1, maintype.x);
+    assert_eq!(2, maintype.y);
+    assert_eq!(1 , maintype.arr1);
+    assert_eq!(3, maintype.arr3);
+    assert_eq!(7.89, maintype.f);
+    
+}


### PR DESCRIPTION
struct instance variables can be statically initialized,
all fields must be set

whats still missing is:
- use initial values defined on the struct's type declaration if the value is not provided in the instance initialization