### PR TITLE
fix problem with transient initialial values in alias-types 

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -847,7 +847,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
                         .ok_or_else(|| CompileError::codegen_error(format!("invalid index entry for {}.{} - no location_in_parent.", struct_name, variable_name), declaration_location.clone()))?;
                     
                     let initial_value = self.index.find_member_initial_value(struct_name, variable_name)
-                        .or(self.index.get_type(member.get_type_name())?.get_initial_value())
+                        .or(self.index.get_type_initial_value(member.get_type_name()))
                         .ok_or_else(|| CompileError::codegen_error(format!("cannot derive initial value for {}.{}", struct_name, variable_name), declaration_location.clone()))?;
                     
                     member_values.push((index_in_parent, initial_value));

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -86,8 +86,7 @@ impl<'a, 'b> PouGenerator<'a, 'b> {
         if pou.pou_type == PouType::Program {
             let instance_initializer = self
                 .index
-                .find_type(pou_name)
-                .and_then(DataTypeIndexEntry::get_initial_value);
+                .get_type_initial_value(pou_name);
             let global_value = self.llvm.create_global_variable(
                     module, 
                     &struct_generator::get_pou_instance_variable_name(pou_name),

--- a/src/codegen/generators/struct_generator.rs
+++ b/src/codegen/generators/struct_generator.rs
@@ -82,8 +82,7 @@ impl<'a, 'b> StructGenerator<'a, 'b> {
                     exp_gen.generate_expression(statement)
                         .map(|(_, value)| Some(value))?
                 }
-                None => 
-                    type_index_entry.get_initial_value()
+                None => self.global_index.get_type_initial_value(type_name),
             };
 
             Ok((variable.name.to_string(), variable_type.get_type(), initializer))

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -36,7 +36,7 @@ pub fn generate_global_variable<'ctx, 'b>(
     } else {
         None
     };
-    let initial_value = initial_value.or(variable_type_index_entry.get_initial_value());
+    let initial_value = initial_value.or(index.get_type_initial_value(type_name));
     let global_ir_variable = llvm.create_global_variable(module, &global_variable.name, variable_type, initial_value);
     index.associate_global_variable(&global_variable.name, global_ir_variable.as_pointer_value());
     Ok(global_ir_variable)

--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -3173,6 +3173,58 @@ source_filename = "main"
 }
 
 #[test]
+fn alias_type_out_of_order() {
+  let result = codegen!(
+        "
+        TYPE MyInt: MyOtherInt1; END_TYPE 
+        VAR_GLOBAL x : MyInt; END_VAR
+
+        TYPE MyOtherInt3 : DINT := 3; END_TYPE
+        TYPE MyOtherInt1 : MyOtherInt2; END_TYPE
+        TYPE MyOtherInt2 : MyOtherInt3; END_TYPE
+        "
+    );
+
+    let expected = r#"; ModuleID = 'main'
+source_filename = "main"
+
+@x = global i32 3
+"#;
+
+  assert_eq!(result, expected);
+}
+
+#[test]
+fn alias_chain_with_lots_of_initializers() {
+  let result = codegen!(
+        "
+        TYPE MyInt: MyOtherInt1; END_TYPE 
+        VAR_GLOBAL 
+          x0 : MyInt; 
+          x1 : MyOtherInt1; 
+          x2 : MyOtherInt2; 
+          x3 : MyOtherInt3; 
+        END_VAR
+
+        TYPE MyOtherInt3 : DINT := 3; END_TYPE
+        TYPE MyOtherInt1 : MyOtherInt2 := 1; END_TYPE
+        TYPE MyOtherInt2 : MyOtherInt3 := 2; END_TYPE
+        "
+    );
+
+    let expected = r#"; ModuleID = 'main'
+source_filename = "main"
+
+@x0 = global i32 1
+@x1 = global i32 1
+@x2 = global i32 2
+@x3 = global i32 3
+"#;
+
+  assert_eq!(result, expected);
+}
+
+#[test]
 fn initial_values_in_type_alias() {
   let result = codegen!(
         "

--- a/src/index.rs
+++ b/src/index.rs
@@ -166,10 +166,6 @@ impl<'ctx> DataTypeIndexEntry<'ctx> {
         self.implementation
     }
 
-    pub fn get_initial_value(&self) -> Option<BasicValueEnum<'ctx>> {
-        self.initial_value
-    } 
-
     pub fn get_name(&self) -> &str {
         self.name.as_str()
     }
@@ -433,6 +429,23 @@ impl<'ctx> Index<'ctx> {
         if let Some(entry) = self.types.get_mut(name) {
             entry.initial_value = Some(initial_value);
         }
+    }
+
+    /// returns the initial value associated to the given datatype
+    ///
+    /// if the given type is an alias type, this will return the initial value of the
+    /// referenced type.
+    pub fn get_type_initial_value(&self, name: &str) -> Option<BasicValueEnum<'ctx>> {
+        let data_type = self.types.get(name);
+        data_type.map(|it| {
+            if it.initial_value.is_some() {
+                return it.initial_value;
+            }
+            if let Some(DataTypeInformation::Alias { referenced_type, .. }) = &it.information {
+                return self.get_type_initial_value(referenced_type.as_str());
+            }
+            None
+        }).flatten()
     }
 
     pub fn associate_member_initial_value(&mut self, container_name: &str, member_name: &str, initial_value: BasicValueEnum<'ctx>) {


### PR DESCRIPTION
_ removed accessing type-initializers via the index-entry
  --> added a methond in the index that respects an alias chain
      since there are only limited situations (declarations)
      we can tolerate the method instead of an accessor in the
      index-entry

_ pre-data_type generation step (generate-stubs) now associates the
      the initial values if they are defined for an alias so the
      generate_datatype can already see them


fixes #151 