### PR TITLE
cascading initial values for alias-types

### DIFF
--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -119,13 +119,16 @@ fn generate_initial_value<'ink>(
                 }, "LiteralString").unwrap()
 
             },
-            DataTypeInformation::Alias { .. } => {
+            DataTypeInformation::Alias { referenced_type, .. } => {
                 if let Some(initializer) = &data_type.initial_value {
                     let generator = ExpressionCodeGenerator::new_context_free(llvm, index, types_index, None);
                     let (_, initial_value) = generator.generate_expression(initializer).unwrap();
                     Some(initial_value)
                 } else {
-                    None
+                    // if there's no initializer defined for this alias, we go and check the aliased type for an initial value
+                    index.get_types().get(referenced_type)
+                        .and_then(|referenced_data_type| 
+                            generate_initial_value(index, types_index, llvm, referenced_data_type))
                 }
             },
             // Void types are not basic type enums, so we return an int here 

--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -3188,6 +3188,35 @@ source_filename = "main"
 }
 
 #[test]
+fn alias_chain_with_lots_of_initializers() {
+  let result = codegen!(
+        "
+        TYPE MyInt: MyOtherInt1; END_TYPE 
+        VAR_GLOBAL 
+          x0 : MyInt; 
+          x1 : MyOtherInt1; 
+          x2 : MyOtherInt2; 
+          x3 : MyOtherInt3; 
+        END_VAR
+        TYPE MyOtherInt3 : DINT := 3; END_TYPE
+        TYPE MyOtherInt1 : MyOtherInt2 := 1; END_TYPE
+        TYPE MyOtherInt2 : MyOtherInt3 := 2; END_TYPE
+        "
+    );
+
+    let expected = r#"; ModuleID = 'main'
+source_filename = "main"
+
+@x0 = global i32 1
+@x1 = global i32 1
+@x2 = global i32 2
+@x3 = global i32 3
+"#;
+
+  assert_eq!(result, expected);
+}
+
+#[test]
 fn initial_values_in_single_dimension_array_variable(){
    let result = codegen!(
         "


### PR DESCRIPTION
initial_value for alias now also consideres referenced type initial value

fixes Alias-Types dont work with unlucky order of definition #151