### PR TITLE
parse support & codegen for subRangeType

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Structured text compiler written in Rust
 - :heavy_check_mark: Enum types
 - :heavy_check_mark: Array data types
 - :heavy_check_mark: Alias types
-- :x: Sub-ranges types
+- :heavy_check_mark: Sub-ranges types
 - :heavy_check_mark: Sized String types
 - :heavy_check_mark: Initial values
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,5 @@
-use crate::compile_error::CompileError;
 /// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use crate::compile_error::CompileError;
 use std::{
     fmt::{Debug, Display, Formatter, Result},
     iter, result, unimplemented,
@@ -227,6 +227,7 @@ pub enum DataType {
     SubRangeType {
         name: Option<String>,
         referenced_type: String,
+        bounds: Option<Statement>,
     },
     ArrayType {
         name: Option<String>,
@@ -256,10 +257,12 @@ impl Debug for DataType {
             DataType::SubRangeType {
                 name,
                 referenced_type,
+                bounds,
             } => f
                 .debug_struct("SubRangeType")
                 .field("name", name)
                 .field("referenced_type", referenced_type)
+                .field("bounds", bounds)
                 .finish(),
             DataType::ArrayType {
                 name,
@@ -300,9 +303,9 @@ impl DataType {
         match self {
             DataType::StructType { name, variables: _ } => name.as_ref().map(|x| x.as_str()),
             DataType::EnumType { name, elements: _ } => name.as_ref().map(|x| x.as_str()),
-            DataType::SubRangeType { name, .. } => name.as_ref().map(|x| x.as_str()),
             DataType::ArrayType { name, .. } => name.as_ref().map(|x| x.as_str()),
             DataType::StringType { name, .. } => name.as_ref().map(|x| x.as_str()),
+            DataType::SubRangeType { name, .. } => name.as_ref().map(|x| x.as_str()),
         }
     }
 

--- a/src/codegen/generators/llvm.rs
+++ b/src/codegen/generators/llvm.rs
@@ -1,3 +1,4 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::{
     ast::SourceRange,
     codegen::{TypeAndPointer, TypeAndValue},
@@ -5,7 +6,6 @@ use crate::{
     index::Index,
     typesystem,
 };
-/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use inkwell::{
     builder::Builder,
     context::Context,

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -1,10 +1,10 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use super::{
     expression_generator::ExpressionCodeGenerator,
     llvm::LLVM,
     statement_generator::{FunctionContext, StatementCodeGenerator},
 };
 use crate::codegen::llvm_index::LLVMTypedIndex;
-/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
 /// The pou_generator contains functions to generate the code for POUs (PROGRAM, FUNCTION, FUNCTION_BLOCK)
 /// # responsibilities

--- a/src/codegen/generators/struct_generator.rs
+++ b/src/codegen/generators/struct_generator.rs
@@ -1,5 +1,5 @@
-use super::{expression_generator::ExpressionCodeGenerator, llvm::LLVM};
 /// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use super::{expression_generator::ExpressionCodeGenerator, llvm::LLVM};
 use crate::index::Index;
 use crate::{
     codegen::llvm_index::LLVMTypedIndex, compile_error::CompileError, index::VariableIndexEntry,

--- a/src/codegen/llvm_index.rs
+++ b/src/codegen/llvm_index.rs
@@ -1,6 +1,6 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::compile_error::CompileError;
 use inkwell::types::BasicTypeEnum;
-/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use inkwell::values::{BasicValueEnum, FunctionValue, GlobalValue, PointerValue};
 use std::collections::HashMap;
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -204,20 +204,24 @@ impl Index {
             .ok_or_else(|| CompileError::unknown_type(type_name, 0..0))
     }
 
-    /// Retrieves the "Effctive" type behind this datatype
+    /// Retrieves the "Effective" type behind this datatype
     /// An effective type will be any end type i.e. Structs, Integers, Floats, String and Array
     pub fn find_effective_type<'ret>(
         &'ret self,
         data_type: &'ret DataTypeInformation,
     ) -> Option<&'ret DataTypeInformation> {
-        if let DataTypeInformation::Alias {
-            referenced_type, ..
-        } = data_type
-        {
-            self.find_type(&referenced_type)
-                .and_then(|it| self.find_effective_type(it.get_type_information()))
-        } else {
-            Some(data_type)
+        match data_type {
+            DataTypeInformation::SubRange {
+                referenced_type, ..
+            } => self
+                .find_type(&referenced_type)
+                .and_then(|it| self.find_effective_type(it.get_type_information())),
+            DataTypeInformation::Alias {
+                referenced_type, ..
+            } => self
+                .find_type(&referenced_type)
+                .and_then(|it| self.find_effective_type(it.get_type_information())),
+            _ => Some(data_type),
         }
     }
 

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -1,12 +1,12 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use super::super::ast::{
     evaluate_constant_int, get_array_dimensions, CompilationUnit, DataType, DataTypeDeclaration,
     PouType, VariableBlock, VariableBlockType, POU,
 };
 use super::Index;
 use super::VariableType;
-/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::ast::Implementation;
 use crate::ast::{self, UserTypeDeclaration};
+use crate::ast::{Implementation, Statement};
 use crate::typesystem::*;
 
 pub fn visit(unit: &CompilationUnit) -> Index {
@@ -206,11 +206,19 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
         DataType::SubRangeType {
             name,
             referenced_type,
-            ..
+            bounds,
         } => {
-            let information = DataTypeInformation::Alias {
-                name: name.as_ref().unwrap().into(),
-                referenced_type: referenced_type.into(),
+            let information = if let Some(Statement::RangeStatement { start, end }) = bounds {
+                DataTypeInformation::SubRange {
+                    name: name.as_ref().unwrap().into(),
+                    referenced_type: referenced_type.into(),
+                    sub_range: (*start.clone()..*end.clone()),
+                }
+            } else {
+                DataTypeInformation::Alias {
+                    name: name.as_ref().unwrap().into(),
+                    referenced_type: referenced_type.into(),
+                }
             };
             index.register_type(
                 name.as_ref().unwrap(),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,6 +1,6 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use core::ops::Range;
 use logos::Filter;
-/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use logos::Lexer;
 use logos::Logos;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -393,6 +393,32 @@ fn parse_data_type_definition(
         //Subrange
         let referenced_type = slice_and_advance(lexer);
 
+        if allow(KeywordParensOpen, lexer) {
+            let bounds = parse_expression(lexer)?;
+            expect!(KeywordParensClose, lexer);
+            lexer.advance();
+
+            let initial_value = if allow(KeywordAssignment, lexer) {
+                Some(parse_expression(lexer)?)
+            } else {
+                None
+            };
+
+            expect!(KeywordSemicolon, lexer);
+            lexer.advance();
+
+            return Ok((
+                DataTypeDeclaration::DataTypeDefinition {
+                    data_type: DataType::SubRangeType {
+                        name,
+                        bounds: Some(bounds),
+                        referenced_type,
+                    },
+                },
+                initial_value,
+            ));
+        }
+
         if name.is_some() {
             let initial_value = if allow(KeywordAssignment, lexer) {
                 Some(parse_expression(lexer)?)
@@ -403,6 +429,7 @@ fn parse_data_type_definition(
                 data_type: DataType::SubRangeType {
                     name,
                     referenced_type,
+                    bounds: None,
                 },
             };
             expect!(KeywordSemicolon, lexer);

--- a/src/parser/control_parser.rs
+++ b/src/parser/control_parser.rs
@@ -1,6 +1,6 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::ast::*;
 use crate::expect;
-/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::lexer;
 use crate::lexer::Token::*;
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,4 +1,4 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 mod control_parser_tests;
 mod expressions_parser_tests;
-/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 mod parser_tests;

--- a/src/parser/tests/control_parser_tests.rs
+++ b/src/parser/tests/control_parser_tests.rs
@@ -1,5 +1,5 @@
-use crate::parser::parse;
 /// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use crate::parser::parse;
 use crate::{ast::Statement, lexer};
 use pretty_assertions::*;
 

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1,5 +1,5 @@
-use crate::parser::parse;
 /// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use crate::parser::parse;
 use crate::{
     ast::{Operator, Statement},
     lexer,

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -1,7 +1,16 @@
 /// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use std::ops::Range;
+
 use crate::ast::{Dimension, Statement};
 
 pub const DEFAULT_STRING_LEN: u32 = 80;
+
+//CheckRan­geSigned, CheckLRangeSigned or CheckRangeUnsigned, CheckLRangeUnsigned
+pub const RANGE_CHECK_S_FN: &str = "CheckRangeSigned";
+pub const RANGE_CHECK_LS_FN: &str = "CheckLRangeSigned";
+pub const RANGE_CHECK_U_FN: &str = "CheckRangeUnsigned";
+pub const RANGE_CHECK_LU_FN: &str = "CheckLRangeUnsigned";
+
 #[derive(Debug, PartialEq)]
 pub struct DataType {
     pub name: String,
@@ -48,6 +57,11 @@ pub enum DataTypeInformation {
     String {
         size: u32,
     },
+    SubRange {
+        name: String,
+        referenced_type: String,
+        sub_range: Range<Statement>,
+    },
     Alias {
         name: String,
         referenced_type: String,
@@ -63,8 +77,9 @@ impl DataTypeInformation {
             DataTypeInformation::Integer { name, .. } => name,
             DataTypeInformation::Float { name, .. } => name,
             DataTypeInformation::String { .. } => "String",
-            DataTypeInformation::Alias { name, .. } => name,
+            DataTypeInformation::SubRange { name, .. } => name,
             DataTypeInformation::Void => "Void",
+            DataTypeInformation::Alias { name, .. } => name,
         }
     }
 
@@ -98,6 +113,7 @@ impl DataTypeInformation {
             DataTypeInformation::String { size, .. } => *size,
             DataTypeInformation::Struct { .. } => 0, //TODO : Should we fill in the struct members here for size calculation or save the struct size.
             DataTypeInformation::Array { .. } => unimplemented!(), //Propably length * inner type size
+            DataTypeInformation::SubRange { .. } => unimplemented!(),
             DataTypeInformation::Alias { .. } => unimplemented!(),
             DataTypeInformation::Void => 0,
         }

--- a/tests/correctness/datatypes.rs
+++ b/tests/correctness/datatypes.rs
@@ -1,5 +1,5 @@
-use super::super::*;
 /// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use super::super::*;
 use std::str;
 #[allow(dead_code)]
 #[repr(C)]

--- a/tests/correctness/sub_range_types.rs
+++ b/tests/correctness/sub_range_types.rs
@@ -1,0 +1,87 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use super::super::*;
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(PartialEq, Debug)]
+struct MainType {
+    _byte: i8,
+    _sint: i8,
+    _usint: u8,
+    _word: i16,
+    _int: i16,
+    _uint: u16,
+    _dint: i32,
+    _udint: u32,
+    _lint: i64,
+    _ulint: u64,
+}
+
+#[test]
+fn sub_range_chooses_right_implementation() {
+    let function = r"
+        FUNCTION CheckRangeSigned : DINT
+        VAR_INPUT v: DINT; low: DINT; up: DINT; END_VAR
+        CheckRangeSigned := -7;
+        END_FUNCTION
+
+        FUNCTION CheckRangeUnsigned : UDINT
+        VAR_INPUT v: UDINT; low: UDINT; up: UDINT; END_VAR
+        CheckRangeUnsigned := 7;
+        END_FUNCTION
+
+        FUNCTION CheckLRangeSigned : LINT
+        VAR_INPUT v: LINT; low: LINT; up: LINT; END_VAR
+        CheckLRangeSigned := -77;
+        END_FUNCTION
+
+        FUNCTION CheckLRangeUnsigned : ULINT
+        VAR_INPUT v: ULINT; low: ULINT; up: ULINT; END_VAR
+        CheckLRangeUnsigned := 77;
+        END_FUNCTION
+        
+        PROGRAM main
+        VAR
+            a   : BYTE(-100 .. 100);
+            b   : SINT(-100 .. 100);
+            c   : USINT(0 .. 100);
+            d   : WORD(-100 .. 100);
+            e   : INT(-100 .. 100);
+            f   : UINT(0 .. 100);
+            g   : DINT(-100 .. 100);
+            h   : UDINT(0 .. 100);
+            i   : LINT(-100 .. 100);
+            j   : ULINT(0 .. 100);
+        END_VAR
+        a := 1; b := 1; c := 1; d := 1; e := 1;
+        f := 1; g := 1; h := 1; i := 1; j := 1;
+        END_PROGRAM
+        ";
+
+    let mut maintype = MainType {
+        _byte: 0,
+        _sint: 0,
+        _usint: 0,
+        _word: 0,
+        _int: 0,
+        _uint: 0,
+        _dint: 0,
+        _udint: 0,
+        _lint: 0,
+        _ulint: 0,
+    };
+
+    compile_and_run(function.to_string(), &mut maintype);
+    let expected = MainType {
+        _byte: 7,
+        _sint: -7,
+        _usint: 7,
+        _word: 7,
+        _int: -7,
+        _uint: 7,
+        _dint: -7,
+        _udint: 7,
+        _lint: -77,
+        _ulint: 77,
+    };
+    assert_eq!(expected, maintype);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
+/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use inkwell::context::Context;
 use inkwell::execution_engine::{ExecutionEngine, JitFunction};
-/// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use rusty::*;
 
 type MainFunction<T> = unsafe extern "C" fn(*mut T) -> i32;
@@ -14,6 +14,7 @@ mod correctness {
     mod functions;
     mod global_variables;
     mod initial_values;
+    mod sub_range_types;
     mod sums;
 }
 


### PR DESCRIPTION
_ calls apropriate sub-range check function
_ chooses the appropriate check function based on the
variables datatype.
_ added unit & correctness tests

apply format to enable rebase
fixes #150 