### PR TITLE
Remove panics and unwraps from parser and LLVM

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -712,11 +712,12 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
                     //Make sure dimensions match statement list
                     let statements = access.get_as_list();
                     if statements.is_empty() || statements.len() != dimensions.len() {
-                        panic!(
+                        return Err(CompileError::codegen_error(
+                        format!(
                             "Mismatched array access : {} -> {} ",
                             statements.len(),
                             dimensions.len()
-                        )
+                        ),access.get_location()));
                     }
                     for (i, statement) in statements.iter().enumerate() {
                         indices.push(self.generate_access_for_dimension(&dimensions[i], statement)?)

--- a/src/codegen/generators/llvm.rs
+++ b/src/codegen/generators/llvm.rs
@@ -183,7 +183,7 @@ impl<'a> Llvm<'a> {
 
             Ok((data_type, BasicValueEnum::IntValue(value.unwrap())))
         } else {
-            panic!("error expected inttype");
+            Err(CompileError::codegen_error("error expected inttype".into(),0..0))
         }
     }
 
@@ -206,7 +206,7 @@ impl<'a> Llvm<'a> {
             let data_type = index.get_type_information("REAL")?;
             Ok((data_type, BasicValueEnum::FloatValue(value)))
         } else {
-            panic!("error expected floattype")
+            Err(CompileError::codegen_error("error expected floattype".into(),0..0))
         }
     }
 

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -87,7 +87,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
         let function_declaration = self.create_llvm_function_type(
             vec![instance_struct_type.ptr_type(AddressSpace::Generic).into()],
             return_type,
-        );
+        )?;
 
         let curr_f = module.add_function(pou_name, function_declaration, None);
         Ok(curr_f)
@@ -163,20 +163,20 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
         &self,
         parameters: Vec<BasicTypeEnum<'ink>>,
         return_type: Option<BasicTypeEnum<'ink>>,
-    ) -> FunctionType<'ink> {
+    ) -> Result<FunctionType<'ink>, CompileError> {
         let params = parameters.as_slice();
         match return_type {
             Some(enum_type) if enum_type.is_int_type() => {
-                enum_type.into_int_type().fn_type(params, false)
+                Ok(enum_type.into_int_type().fn_type(params, false))
             }
             Some(enum_type) if enum_type.is_float_type() => {
-                enum_type.into_float_type().fn_type(params, false)
+                Ok(enum_type.into_float_type().fn_type(params, false))
             }
             Some(enum_type) if enum_type.is_array_type() => {
-                enum_type.into_array_type().fn_type(params, false)
+                Ok(enum_type.into_array_type().fn_type(params, false))
             }
-            None => self.llvm.context.void_type().fn_type(params, false),
-            _ => panic!("Unsupported return type {:?}", return_type),
+            None => Ok(self.llvm.context.void_type().fn_type(params, false)),
+            _ => Err(CompileError::codegen_error(format!("Unsupported return type {:?}", return_type),0..0)),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ fn get_ir(codegen: &codegen::CodeGen) -> String {
 /// * `context` - the LLVM Context to be used for the compilation
 /// * `source` - the source to be compiled
 pub fn compile_module(context: &Context, source: String) -> Result<codegen::CodeGen, CompileError> {
-    let (mut parse_result, _) = parse(source);
+    let (mut parse_result, _) = parse(source)?;
     //first pre-process the AST
     ast::pre_process(&mut parse_result);
     //then index the AST
@@ -174,9 +174,10 @@ pub fn compile_module(context: &Context, source: String) -> Result<codegen::Code
     Ok(code_generator)
 }
 
-fn parse(source: String) -> (ast::CompilationUnit, NewLines) {
+fn parse(source: String) -> Result<(ast::CompilationUnit, NewLines), CompileError> {
     //Start lexing
     let lexer = lexer::lex(&source);
     //Parse
-    parser::parse(lexer).unwrap()
+    //TODO : Parser should also return compile errors with sane locations
+    parser::parse(lexer).map_err(|err| CompileError::codegen_error(err, 0..0))
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -318,14 +318,14 @@ fn parse_data_type_definition(
         expect!(KeywordSquareParensOpen, lexer);
         lexer.advance();
         //parse range
-        let range = parse_primary_expression(lexer).unwrap();
+        let range = parse_primary_expression(lexer)?;
         //expect close range
         expect!(KeywordSquareParensClose, lexer);
         lexer.advance();
         expect!(KeywordOf, lexer);
         lexer.advance();
         //expect type reference
-        let (reference, initializer) = parse_data_type_definition(lexer, None).unwrap();
+        let (reference, initializer) = parse_data_type_definition(lexer, None)?;
         Ok((
             DataTypeDeclaration::DataTypeDefinition {
                 data_type: DataType::ArrayType {
@@ -537,7 +537,7 @@ fn parse_variable_block(lexer: &mut RustyLexer) -> Result<VariableBlock, String>
 
     let mut result = VariableBlock {
         variables: Vec::new(),
-        variable_block_type: parse_variable_block_type(lexer).unwrap(),
+        variable_block_type: parse_variable_block_type(lexer)?,
     };
 
     while lexer.token == Identifier {

--- a/src/parser/control_parser.rs
+++ b/src/parser/control_parser.rs
@@ -63,19 +63,19 @@ fn parse_for_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     let start = lexer.range().start;
     lexer.advance(); // FOR
 
-    let counter_expression = parse_reference(lexer).unwrap();
+    let counter_expression = parse_reference(lexer)?;
     expect!(KeywordAssignment, lexer); // :=
     lexer.advance();
 
-    let start_expression = parse_expression(lexer).unwrap();
+    let start_expression = parse_expression(lexer)?;
 
     expect!(KeywordTo, lexer); // TO
     lexer.advance();
-    let end_expression = parse_expression(lexer).unwrap();
+    let end_expression = parse_expression(lexer)?;
 
     let step = if lexer.token == KeywordBy {
         lexer.advance(); // BY
-        Some(Box::new(parse_expression(lexer).unwrap()))
+        Some(Box::new(parse_expression(lexer)?))
     } else {
         None
     };
@@ -158,15 +158,17 @@ fn parse_case_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
         expect!(KeywordColon, lexer); // :
         lexer.advance();
 
-        loop {
-            let (body, next_condition) =
-                parse_case_body_with_condition(condition.unwrap(), lexer, case_line_nr)?;
-            condition = next_condition;
-            case_blocks.push(body);
+        if condition.is_some() {
+            loop {
+                let (body, next_condition) =
+                    parse_case_body_with_condition(condition.unwrap(), lexer, case_line_nr)?;
+                condition = next_condition;
+                case_blocks.push(body);
 
-            if !(lexer.token != KeywordEndCase && lexer.token != KeywordElse && condition.is_some())
-            {
-                break;
+                if !(lexer.token != KeywordEndCase && lexer.token != KeywordElse && condition.is_some())
+                {
+                    break;
+                }
             }
         }
     }

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -272,7 +272,7 @@ pub fn parse_qualified_reference(lexer: &mut RustyLexer) -> Result<Statement, St
         let (statement_list, end) = if allow(KeywordParensClose, lexer) {
             (None, lexer.range().end)
         } else {
-            let list = parse_expression_list(lexer).unwrap();
+            let list = parse_expression_list(lexer)?;
             expect!(KeywordParensClose, lexer);
             let end = lexer.range().end;
             lexer.advance();


### PR DESCRIPTION
Errors should be propagated to main
This commits makes sure the parser does not panic .
Some LLVM and Codegen functions were also still panicing/unwrapping.