### PR TITLE
Make the AST hold a file location

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::index::Index;
+use crate::{ast::SourceRange, index::Index};
 use inkwell::{
     basic_block::BasicBlock,
     types::BasicTypeEnum,
@@ -9,7 +9,7 @@ use inkwell::{
     },
     AddressSpace, FloatPredicate, IntPredicate,
 };
-use std::{collections::HashSet, ops::Range};
+use std::collections::HashSet;
 
 use crate::{
     ast::{flatten_expression_list, Dimension, Operator, Statement},
@@ -767,11 +767,13 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
                     let statements = access.get_as_list();
                     if statements.is_empty() || statements.len() != dimensions.len() {
                         return Err(CompileError::codegen_error(
-                        format!(
-                            "Mismatched array access : {} -> {} ",
-                            statements.len(),
-                            dimensions.len()
-                        ),access.get_location()));
+                            format!(
+                                "Mismatched array access : {} -> {} ",
+                                statements.len(),
+                                dimensions.len()
+                            ),
+                            access.get_location(),
+                        ));
                     }
                     for (i, statement) in statements.iter().enumerate() {
                         indices.push(self.generate_access_for_dimension(&dimensions[i], statement)?)
@@ -1109,7 +1111,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
     fn generate_literal_struct(
         &self,
         assignments: &Statement,
-        declaration_location: &Range<usize>,
+        declaration_location: &SourceRange,
     ) -> Result<TypeAndValue<'a>, CompileError> {
         if let Some(type_info) = &self.type_hint {
             if let DataTypeInformation::Struct {
@@ -1223,7 +1225,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
     fn generate_literal_array(
         &self,
         elements: &Option<Box<Statement>>,
-        location: &Range<usize>,
+        location: &SourceRange,
     ) -> Result<TypeAndValue<'a>, CompileError> {
         if let Some(type_info) = &self.type_hint {
             if let DataTypeInformation::Array {

--- a/src/codegen/generators/llvm.rs
+++ b/src/codegen/generators/llvm.rs
@@ -183,7 +183,10 @@ impl<'a> Llvm<'a> {
 
             Ok((data_type, BasicValueEnum::IntValue(value.unwrap())))
         } else {
-            Err(CompileError::codegen_error("error expected inttype".into(),0..0))
+            Err(CompileError::codegen_error(
+                "error expected inttype".into(),
+                SourceRange::undefined(),
+            ))
         }
     }
 
@@ -206,7 +209,10 @@ impl<'a> Llvm<'a> {
             let data_type = index.get_type_information("REAL")?;
             Ok((data_type, BasicValueEnum::FloatValue(value)))
         } else {
-            Err(CompileError::codegen_error("error expected floattype".into(),0..0))
+            Err(CompileError::codegen_error(
+                "error expected floattype".into(),
+                SourceRange::undefined(),
+            ))
         }
     }
 

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -150,7 +150,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
             &function_context,
             &local_index,
             implementation.pou_type,
-            Some(0..0),
+            None,
         )?; //TODO location
 
         Ok(())
@@ -176,7 +176,10 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
                 Ok(enum_type.into_array_type().fn_type(params, false))
             }
             None => Ok(self.llvm.context.void_type().fn_type(params, false)),
-            _ => Err(CompileError::codegen_error(format!("Unsupported return type {:?}", return_type),0..0)),
+            _ => Err(CompileError::codegen_error(
+                format!("Unsupported return type {:?}", return_type),
+                SourceRange::undefined(),
+            )),
         }
     }
 
@@ -258,7 +261,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
             PouType::Function => {
                 let reference = Statement::Reference {
                     name: function_context.linking_context.get_call_name().into(),
-                    location: location.unwrap_or(0usize..0usize),
+                    location: location.unwrap_or_else(SourceRange::undefined),
                 };
                 let mut exp_gen = ExpressionCodeGenerator::new(
                     &self.llvm,

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -2,9 +2,9 @@
 use std::ops::Range;
 
 use super::{expression_generator::ExpressionCodeGenerator, llvm::Llvm};
-use crate::codegen::llvm_typesystem::cast_if_needed;
 use crate::codegen::LlvmTypedIndex;
 use crate::typesystem::{RANGE_CHECK_LS_FN, RANGE_CHECK_LU_FN, RANGE_CHECK_S_FN, RANGE_CHECK_U_FN};
+use crate::{ast::SourceRange, codegen::llvm_typesystem::cast_if_needed};
 use crate::{
     ast::{flatten_expression_list, ConditionalBlock, Operator, Statement},
     compile_error::CompileError,
@@ -281,10 +281,10 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
 
     /// genertes a case statement
     ///
-    /// CASE selector OF  
-    /// conditional_block#1:  
-    /// conditional_block#2:  
-    /// END_CASE;  
+    /// CASE selector OF
+    /// conditional_block#1:
+    /// conditional_block#2:
+    /// END_CASE;
     ///
     /// - `selector` the case's selector expression
     /// - `conditional_blocks` all case-blocks including the condition and the body
@@ -424,9 +424,9 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
 
     /// generates a while statement
     ///
-    /// WHILE condition DO  
-    ///     body  
-    /// END_WHILE  
+    /// WHILE condition DO
+    ///     body
+    /// END_WHILE
     ///
     /// - `condition` the while's condition
     /// - `body` the while's body statements
@@ -452,9 +452,9 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
     /// generates a repeat statement
     ///
     ///
-    /// REPEAT  
-    ///     body  
-    /// UNTIL condition END_REPEAT;  
+    /// REPEAT
+    ///     body
+    /// UNTIL condition END_REPEAT;
     ///
     /// - `condition` the repeat's condition
     /// - `body` the repeat's body statements
@@ -601,7 +601,7 @@ fn create_call_to_check_function_ast(
     check_function_name: String,
     parameter: Statement,
     sub_range: Range<Statement>,
-    location: &Range<usize>,
+    location: &SourceRange,
 ) -> Statement {
     Statement::CallStatement {
         operator: Box::new(Statement::Reference {

--- a/src/codegen/llvm_index.rs
+++ b/src/codegen/llvm_index.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::compile_error::CompileError;
+use crate::{ast::SourceRange, compile_error::CompileError};
 use inkwell::types::BasicTypeEnum;
 use inkwell::values::{BasicValueEnum, FunctionValue, GlobalValue, PointerValue};
 use std::collections::HashMap;
@@ -99,7 +99,7 @@ impl<'ink> LlvmTypedIndex<'ink> {
         type_name: &str,
     ) -> Result<BasicTypeEnum<'ink>, CompileError> {
         self.find_associated_type(type_name)
-            .ok_or_else(|| CompileError::unknown_type(type_name, 0..0))
+            .ok_or_else(|| CompileError::unknown_type(type_name, SourceRange::undefined()))
     }
 
     pub fn find_associated_initial_value(&self, type_name: &str) -> Option<BasicValueEnum<'ink>> {

--- a/src/codegen/llvm_typesystem.rs
+++ b/src/codegen/llvm_typesystem.rs
@@ -7,6 +7,7 @@ use inkwell::{
 };
 
 use crate::{
+    ast::SourceRange,
     ast::Statement,
     compile_error::CompileError,
     index::Index,
@@ -161,13 +162,13 @@ pub fn cast_if_needed<'ctx>(
     let target_type = index.find_effective_type(target_type).ok_or_else(|| {
         CompileError::codegen_error(
             format!("Could not find primitive type for {:?}", target_type),
-            0..0,
+            SourceRange::undefined(),
         )
     })?;
     let value_type = index.find_effective_type(value_type).ok_or_else(|| {
         CompileError::codegen_error(
             format!("Could not find primitive type for {:?}", value_type),
-            0..0,
+            SourceRange::undefined(),
         )
     })?;
     match target_type {
@@ -322,7 +323,7 @@ pub fn get_llvm_int_type<'a>(
         128 => Ok(context.i128_type()),
         _ => Err(CompileError::codegen_error(
             format!("Invalid size for type : '{}' at {}", name, size),
-            0..0,
+            SourceRange::undefined(),
         )),
     }
 }
@@ -337,7 +338,7 @@ pub fn get_llvm_float_type<'a>(
         64 => Ok(context.f64_type()),
         _ => Err(CompileError::codegen_error(
             format!("Invalid size for type : '{}' at {}", name, size),
-            0..0,
+            SourceRange::undefined(),
         )),
     }
 }

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -6,7 +6,7 @@ mod typesystem_test;
 #[macro_export]
 macro_rules! codegen_wihout_unwrap {
     ($code:tt) => {{
-        let lexer = crate::lexer::lex($code);
+        let lexer = crate::lexer::lex("", $code);
         let (mut ast, _) = crate::parser::parse(lexer).unwrap();
 
         let context = inkwell::context::Context::create();
@@ -20,7 +20,7 @@ macro_rules! codegen_wihout_unwrap {
 #[macro_export]
 macro_rules! codegen {
     ($code:tt) => {{
-        let lexer = crate::lexer::lex($code);
+        let lexer = crate::lexer::lex("", $code);
         let (mut ast, _) = crate::parser::parse(lexer).unwrap();
 
         let context = inkwell::context::Context::create();

--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -3939,7 +3939,7 @@ fn struct_initializer_needs_assignments() {
         Err(CompileError::codegen_error(
             "struct literal must consist of explicit assignments in the form of member := value"
                 .to_string(),
-            185..186
+            (185..186).into()
         ))
     );
     assert_eq!(source[185..186].to_string(), "2".to_string());

--- a/src/codegen/tests/codegen_error_messages_tests.rs
+++ b/src/codegen/tests/codegen_error_messages_tests.rs
@@ -15,7 +15,7 @@ fn unknown_reference_should_be_reported_with_line_number() {
         "
     );
     if let Err(msg) = result {
-        assert_eq!(CompileError::invalid_reference("y", 100..101), msg);
+        assert_eq!(CompileError::invalid_reference("y", (100..101).into()), msg);
     } else {
         panic!("expected code-gen error but got none")
     }
@@ -37,7 +37,10 @@ fn unknown_type_should_be_reported_with_line_number() {
     if let Err(msg) = result {
         // that's not perfect yet, the error is reported for the region of the variable
         // but better than nothing
-        assert_eq!(CompileError::unknown_type("unknown_type", 17..18), msg);
+        assert_eq!(
+            CompileError::unknown_type("unknown_type", (17..18).into()),
+            msg
+        );
     } else {
         panic!("expected code-gen error but got none")
     }
@@ -65,7 +68,10 @@ fn unknown_struct_field_should_be_reported_with_line_number() {
         "
     );
     if let Err(msg) = result {
-        assert_eq!(CompileError::invalid_reference("MyStruct.c", 264..265), msg);
+        assert_eq!(
+            CompileError::invalid_reference("MyStruct.c", (264..265).into()),
+            msg
+        );
     } else {
         panic!("expected code-gen error but got none")
     }
@@ -87,7 +93,7 @@ fn invalid_array_access_should_be_reported_with_line_number() {
         // that's not perfect yet, the error is reported for the region of the variable
         // but better than nothing
         assert_eq!(
-            CompileError::codegen_error("Invalid array access".to_string(), 97..98),
+            CompileError::codegen_error("Invalid array access".to_string(), (97..98).into()),
             msg
         );
     } else {
@@ -116,7 +122,7 @@ fn invalid_array_access_in_struct_should_be_reported_with_line_number() {
     );
     if let Err(msg) = result {
         assert_eq!(
-            CompileError::codegen_error("Invalid array access".to_string(), 228..229),
+            CompileError::codegen_error("Invalid array access".to_string(), (228..229).into()),
             msg
         );
     } else {
@@ -138,7 +144,10 @@ fn invalid_struct_access_in_array_should_be_reported_with_line_number() {
     let result = codegen_wihout_unwrap!(src);
     if let Err(msg) = result {
         // that's not perfect yet, we need display-names for generated datatypes
-        assert_eq!(CompileError::invalid_reference("INT.a", 114..115), msg)
+        assert_eq!(
+            CompileError::invalid_reference("INT.a", (114..115).into()),
+            msg
+        )
     } else {
         panic!("expected code-gen error but got none")
     }
@@ -159,7 +168,10 @@ fn invalid_struct_access_in_array_access_should_be_reported_with_line_number() {
     let result = codegen_wihout_unwrap!(src);
     if let Err(msg) = result {
         // that's not perfect yet, we need display-names for generated datatypes
-        assert_eq!(CompileError::invalid_reference("INT.index", 139..144), msg)
+        assert_eq!(
+            CompileError::invalid_reference("INT.index", (139..144).into()),
+            msg
+        )
     } else {
         panic!("expected code-gen error but got none")
     }

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -1,47 +1,48 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use std::ops::Range;
 use thiserror::Error;
+
+use crate::ast::SourceRange;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum CompileError {
     #[error("Unknown reference '{reference}' at {location:?}")]
     InvalidReference {
         reference: String,
-        location: core::ops::Range<usize>,
+        location: SourceRange,
     },
 
     #[error("Unknown type '{type_name}' at {location:?}")]
     UnknownType {
         type_name: String,
-        location: core::ops::Range<usize>,
+        location: SourceRange,
     },
 
     #[error("{message}")]
     CodeGenError {
         message: String,
-        location: core::ops::Range<usize>,
+        location: SourceRange,
     },
 
     #[error("Cannot generate code outside of function context at {location:?}")]
-    MissingFunctionError { location: core::ops::Range<usize> },
+    MissingFunctionError { location: SourceRange },
 
     #[error("Cannot cast from {type_name:} to {target_type:} at {location:?}")]
     CastError {
         type_name: String,
         target_type: String,
-        location: core::ops::Range<usize>,
+        location: SourceRange,
     },
 }
 
 impl CompileError {
-    pub fn missing_function(location: Range<usize>) -> CompileError {
+    pub fn missing_function(location: SourceRange) -> CompileError {
         CompileError::MissingFunctionError { location }
     }
 
     pub fn casting_error(
         type_name: &str,
         target_type: &str,
-        location: Range<usize>,
+        location: SourceRange,
     ) -> CompileError {
         CompileError::CastError {
             type_name: type_name.to_string(),
@@ -50,25 +51,25 @@ impl CompileError {
         }
     }
 
-    pub fn invalid_reference(reference: &str, location: Range<usize>) -> CompileError {
+    pub fn invalid_reference(reference: &str, location: SourceRange) -> CompileError {
         CompileError::InvalidReference {
             reference: reference.to_string(),
             location,
         }
     }
 
-    pub fn unknown_type(type_name: &str, location: Range<usize>) -> CompileError {
+    pub fn unknown_type(type_name: &str, location: SourceRange) -> CompileError {
         CompileError::UnknownType {
             type_name: type_name.to_string(),
             location,
         }
     }
 
-    pub fn codegen_error(message: String, location: Range<usize>) -> CompileError {
+    pub fn codegen_error(message: String, location: SourceRange) -> CompileError {
         CompileError::CodeGenError { message, location }
     }
 
-    pub fn no_type_associated(type_name: &str, location: Range<usize>) -> CompileError {
+    pub fn no_type_associated(type_name: &str, location: SourceRange) -> CompileError {
         CompileError::CodeGenError {
             message: format!("No type associated to {:}", type_name),
             location,

--- a/src/index.rs
+++ b/src/index.rs
@@ -207,7 +207,7 @@ impl Index {
 
     pub fn get_type(&self, type_name: &str) -> Result<&DataType, CompileError> {
         self.find_type(type_name)
-            .ok_or_else(|| CompileError::unknown_type(type_name, 0..0))
+            .ok_or_else(|| CompileError::unknown_type(type_name, SourceRange::undefined()))
     }
 
     /// Retrieves the "Effective" type behind this datatype
@@ -258,7 +258,7 @@ impl Index {
         type_name: &str,
     ) -> Result<DataTypeInformation, CompileError> {
         self.find_type_information(type_name)
-            .ok_or_else(|| CompileError::unknown_type(type_name, 0..0))
+            .ok_or_else(|| CompileError::unknown_type(type_name, SourceRange::undefined()))
     }
 
     pub fn get_types(&self) -> &IndexMap<String, DataType> {

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -2,8 +2,8 @@
 use super::VariableType;
 use crate::ast::{
     self, evaluate_constant_int, get_array_dimensions, CompilationUnit, DataType,
-    DataTypeDeclaration, Implementation, Pou, PouType, Statement, UserTypeDeclaration, Variable,
-    VariableBlock, VariableBlockType,
+    DataTypeDeclaration, Implementation, Pou, PouType, SourceRange, Statement, UserTypeDeclaration,
+    Variable, VariableBlock, VariableBlockType,
 };
 use crate::index::{Index, MemberInfo};
 use crate::typesystem::*;
@@ -88,7 +88,10 @@ pub fn visit_pou(index: &mut Index, pou: &Pou) {
     //register a function's return type as a member variable
     if let Some(return_type) = &pou.return_type {
         member_names.push(pou.name.clone());
-        let source_location = pou.location.end..pou.location.end;
+        let source_location = SourceRange::new(
+            &pou.location.get_file_path(),
+            pou.location.get_end()..pou.location.get_end(),
+        );
         index.register_member_variable(
             &MemberInfo {
                 container_name: &pou.name,
@@ -229,9 +232,9 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                     "DINT",
                     Some(ast::Statement::LiteralInteger {
                         value: i.to_string(),
-                        location: 0..0,
+                        location: SourceRange::undefined(),
                     }),
-                    0..0,
+                    SourceRange::undefined(),
                 )
             }); //TODO : Enum locations
         }

--- a/src/lexer/tests/lexer_tests.rs
+++ b/src/lexer/tests/lexer_tests.rs
@@ -1,7 +1,11 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use pretty_assertions::{assert_eq, assert_ne};
 
-use crate::lexer::{lex, Token::*};
+use crate::lexer::{RustyLexer, Token::*};
+
+fn lex(source: &str) -> RustyLexer {
+    crate::lexer::lex("", source)
+}
 
 #[test]
 fn generic_properties() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! [`IR`]: https://llvm.org/docs/LangRef.html
 use std::path::Path;
 
-use ast::NewLines;
+use ast::{NewLines, SourceRange};
 use compile_error::CompileError;
 use inkwell::context::Context;
 use inkwell::targets::{
@@ -42,6 +42,7 @@ extern crate pretty_assertions;
 /// Compiles the given source into an object file and saves it in output
 ///
 fn compile_to_obj(
+    file_path: &str,
     source: String,
     output: &str,
     reloc: RelocMode,
@@ -50,7 +51,7 @@ fn compile_to_obj(
     let path = Path::new(output);
 
     let context = Context::create();
-    let code_generator = compile_module(&context, source)?;
+    let code_generator = compile_module(&context, file_path, source)?;
     let initialization_config = &InitializationConfig::default();
     Target::initialize_all(initialization_config);
 
@@ -88,11 +89,12 @@ fn compile_to_obj(
 /// * `target` - an optional llvm target triple
 ///     If not provided, the machine's triple will be used.
 pub fn compile_to_static_obj(
+    file_path: &str,
     source: String,
     output: &str,
     target: Option<String>,
 ) -> Result<(), CompileError> {
-    compile_to_obj(source, output, RelocMode::Default, target)
+    compile_to_obj(file_path, source, output, RelocMode::Default, target)
 }
 
 /// Compiles a given source string to a shared position independent object and saves the output.
@@ -104,11 +106,12 @@ pub fn compile_to_static_obj(
 /// * `target` - an optional llvm target triple
 ///     If not provided, the machine's triple will be used.
 pub fn compile_to_shared_pic_object(
+    file_path: &str,
     source: String,
     output: &str,
     target: Option<String>,
 ) -> Result<(), CompileError> {
-    compile_to_obj(source, output, RelocMode::PIC, target)
+    compile_to_obj(file_path, source, output, RelocMode::PIC, target)
 }
 
 /// Compiles a given source string to a dynamic non PIC object and saves the output.
@@ -120,11 +123,12 @@ pub fn compile_to_shared_pic_object(
 /// * `target` - an optional llvm target triple
 ///     If not provided, the machine's triple will be used.
 pub fn compile_to_shared_object(
+    file_path: &str,
     source: String,
     output: &str,
     target: Option<String>,
 ) -> Result<(), CompileError> {
-    compile_to_obj(source, output, RelocMode::DynamicNoPic, target)
+    compile_to_obj(file_path, source, output, RelocMode::DynamicNoPic, target)
 }
 
 ///
@@ -134,11 +138,15 @@ pub fn compile_to_shared_object(
 ///
 /// * `source` - the source to be compiled
 /// * `output` - the location on disk to save the output
-pub fn compile_to_bitcode(source: String, output: &str) -> Result<(), CompileError> {
+pub fn compile_to_bitcode(
+    file_path: &str,
+    source: String,
+    output: &str,
+) -> Result<(), CompileError> {
     let path = Path::new(output);
 
     let context = Context::create();
-    let code_generator = compile_module(&context, source)?;
+    let code_generator = compile_module(&context, file_path, source)?;
     code_generator.module.write_bitcode_to_path(path);
     Ok(())
 }
@@ -149,9 +157,9 @@ pub fn compile_to_bitcode(source: String, output: &str) -> Result<(), CompileErr
 /// # Arguments
 ///
 /// * `source` - the source to be compiled
-pub fn compile_to_ir(source: String) -> Result<String, CompileError> {
+pub fn compile_to_ir(file_path: &str, source: String) -> Result<String, CompileError> {
     let context = Context::create();
-    let code_gen = compile_module(&context, source)?;
+    let code_gen = compile_module(&context, file_path, source)?;
     Ok(get_ir(&code_gen))
 }
 
@@ -166,8 +174,12 @@ fn get_ir(codegen: &codegen::CodeGen) -> String {
 ///
 /// * `context` - the LLVM Context to be used for the compilation
 /// * `source` - the source to be compiled
-pub fn compile_module(context: &Context, source: String) -> Result<codegen::CodeGen, CompileError> {
-    let (mut parse_result, _) = parse(source)?;
+pub fn compile_module<'ink, 'file>(
+    context: &'ink Context,
+    file_path: &'file str,
+    source: String,
+) -> Result<codegen::CodeGen<'ink>, CompileError> {
+    let (mut parse_result, _) = parse(file_path, source)?;
     //first pre-process the AST
     ast::pre_process(&mut parse_result);
     //then index the AST
@@ -178,10 +190,13 @@ pub fn compile_module(context: &Context, source: String) -> Result<codegen::Code
     Ok(code_generator)
 }
 
-fn parse(source: String) -> Result<(ast::CompilationUnit, NewLines), CompileError> {
+fn parse(
+    file_path: &str,
+    source: String,
+) -> Result<(ast::CompilationUnit, NewLines), CompileError> {
     //Start lexing
-    let lexer = lexer::lex(&source);
+    let lexer = lexer::lex(file_path, &source);
     //Parse
     //TODO : Parser should also return compile errors with sane locations
-    parser::parse(lexer).map_err(|err| CompileError::codegen_error(err, 0..0))
+    parser::parse(lexer).map_err(|err| CompileError::codegen_error(err, SourceRange::undefined()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ fn compile_to_obj(
 ///
 /// # Arguments
 ///
+/// * `file_path` - the source code's location
 /// * `source` - the source to be compiled
 /// * `output` - the location on disk to save the output
 /// * `target` - an optional llvm target triple
@@ -101,6 +102,7 @@ pub fn compile_to_static_obj(
 ///
 /// # Arguments
 ///
+/// * `file_path` - the source code's location
 /// * `source` - the source to be compiled
 /// * `output` - the location on disk to save the output
 /// * `target` - an optional llvm target triple
@@ -118,6 +120,7 @@ pub fn compile_to_shared_pic_object(
 ///
 /// # Arguments
 ///
+/// * `file_path` - the source code's location
 /// * `source` - the source to be compiled
 /// * `output` - the location on disk to save the output
 /// * `target` - an optional llvm target triple
@@ -136,6 +139,7 @@ pub fn compile_to_shared_object(
 ///
 /// # Arguments
 ///
+/// * `file_path` - the source code's location
 /// * `source` - the source to be compiled
 /// * `output` - the location on disk to save the output
 pub fn compile_to_bitcode(
@@ -156,6 +160,7 @@ pub fn compile_to_bitcode(
 ///
 /// # Arguments
 ///
+/// * `file_path` - the source code's location
 /// * `source` - the source to be compiled
 pub fn compile_to_ir(file_path: &str, source: String) -> Result<String, CompileError> {
     let context = Context::create();
@@ -173,6 +178,7 @@ fn get_ir(codegen: &codegen::CodeGen) -> String {
 /// # Arguments
 ///
 /// * `context` - the LLVM Context to be used for the compilation
+/// * `file_path` - the source code's location
 /// * `source` - the source to be compiled
 pub fn compile_module<'ink, 'file>(
     context: &'ink Context,

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,26 +35,45 @@ fn main() {
 }
 
 fn main_compile(parameters: CompileParameters) {
+    let file_path = parameters.input.as_str();
     let contents = fs::read_to_string(parameters.input.as_str())
         .unwrap_or_else(|_| panic!("Cannot read input file {}", parameters.input.as_str()));
 
     if parameters.output_bit_code {
-        compile_to_bitcode(contents, parameters.output.as_str()).unwrap();
+        compile_to_bitcode(file_path, contents, parameters.output.as_str()).unwrap();
     } else if parameters.output_ir {
-        generate_ir(contents, parameters.output.as_str()).unwrap();
+        generate_ir(file_path, contents, parameters.output.as_str()).unwrap();
     } else if parameters.output_pic_obj {
-        compile_to_shared_object(contents, parameters.output.as_str(), parameters.target).unwrap();
+        compile_to_shared_object(
+            file_path,
+            contents,
+            parameters.output.as_str(),
+            parameters.target,
+        )
+        .unwrap();
     } else if parameters.output_shared_obj {
-        compile_to_shared_object(contents, parameters.output.as_str(), parameters.target).unwrap()
+        compile_to_shared_object(
+            file_path,
+            contents,
+            parameters.output.as_str(),
+            parameters.target,
+        )
+        .unwrap()
     } else if parameters.output_obj_code {
-        compile_to_static_obj(contents, parameters.output.as_str(), parameters.target).unwrap();
+        compile_to_static_obj(
+            file_path,
+            contents,
+            parameters.output.as_str(),
+            parameters.target,
+        )
+        .unwrap();
     } else {
         //none is set, so we use default
         panic!("no output format defined");
     }
 }
-fn generate_ir(content: String, output: &str) -> Result<(), CompileError> {
-    let ir = compile_to_ir(content)?;
+fn generate_ir(file_path: &str, content: String, output: &str) -> Result<(), CompileError> {
+    let ir = compile_to_ir(file_path, content)?;
     fs::write(output, ir).unwrap();
     Ok(())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -194,7 +194,7 @@ fn parse_pou(
         pou_type,
         variable_blocks,
         return_type,
-        location: line_nr..lexer.get_current_line_nr(),
+        location: SourceRange::new(lexer.get_file_path(), line_nr..lexer.get_current_line_nr()),
     };
 
     let implementation = parse_implementation(
@@ -228,7 +228,7 @@ fn parse_implementation(
         linkage,
         pou_type,
         statements,
-        location: start..lexer.get_current_line_nr(),
+        location: SourceRange::new(lexer.get_file_path(), start..lexer.get_current_line_nr()),
     };
     lexer.advance();
 
@@ -553,7 +553,7 @@ fn parse_variable_block(lexer: &mut RustyLexer) -> Result<VariableBlock, String>
 }
 
 fn parse_variable(lexer: &mut RustyLexer) -> Result<Variable, String> {
-    let variable_range = lexer.range();
+    let variable_location = lexer.location();
     let name = slice_and_advance(lexer);
 
     expect!(KeywordColon, lexer);
@@ -565,7 +565,7 @@ fn parse_variable(lexer: &mut RustyLexer) -> Result<Variable, String> {
     Ok(Variable {
         name,
         data_type,
-        location: variable_range,
+        location: variable_location,
         initializer,
     })
 }

--- a/src/parser/control_parser.rs
+++ b/src/parser/control_parser.rs
@@ -55,7 +55,7 @@ fn parse_if_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     Ok(Statement::IfStatement {
         blocks: conditional_blocks,
         else_block,
-        location: start..end,
+        location: SourceRange::new(lexer.get_file_path(), start..end),
     })
 }
 
@@ -95,7 +95,7 @@ fn parse_for_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
         end: Box::new(end_expression),
         by_step: step,
         body: body?,
-        location: start..end,
+        location: SourceRange::new(lexer.get_file_path(), start..end),
     })
 }
 
@@ -117,7 +117,7 @@ fn parse_while_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     Ok(Statement::WhileLoopStatement {
         condition,
         body,
-        location: start..end,
+        location: SourceRange::new(lexer.get_file_path(), start..end),
     })
 }
 
@@ -138,7 +138,7 @@ fn parse_repeat_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
     Ok(Statement::RepeatLoopStatement {
         condition,
         body,
-        location: start..end,
+        location: SourceRange::new(lexer.get_file_path(), start..end),
     })
 }
 
@@ -165,7 +165,9 @@ fn parse_case_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
                 condition = next_condition;
                 case_blocks.push(body);
 
-                if !(lexer.token != KeywordEndCase && lexer.token != KeywordElse && condition.is_some())
+                if !(lexer.token != KeywordEndCase
+                    && lexer.token != KeywordElse
+                    && condition.is_some())
                 {
                     break;
                 }
@@ -189,7 +191,7 @@ fn parse_case_statement(lexer: &mut RustyLexer) -> Result<Statement, String> {
         selector,
         case_blocks,
         else_block,
-        location: start..end,
+        location: SourceRange::new(lexer.get_file_path(), start..end),
     })
 }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2,3 +2,7 @@
 mod control_parser_tests;
 mod expressions_parser_tests;
 mod parser_tests;
+
+pub fn lex(source: &str) -> crate::lexer::RustyLexer {
+    crate::lexer::lex("", source)
+}

--- a/src/parser/tests/control_parser_tests.rs
+++ b/src/parser/tests/control_parser_tests.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use crate::ast::Statement;
 use crate::parser::parse;
-use crate::{ast::Statement, lexer};
 use pretty_assertions::*;
 
 #[test]
 fn if_statement() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         IF TRUE THEN
@@ -35,7 +35,7 @@ fn if_statement() {
 
 #[test]
 fn if_else_statement_with_expressions() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         IF TRUE THEN
@@ -76,7 +76,7 @@ fn if_else_statement_with_expressions() {
 
 #[test]
 fn if_elsif_elsif_else_statement_with_expressions() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         IF TRUE THEN
@@ -141,7 +141,7 @@ fn if_elsif_elsif_else_statement_with_expressions() {
 
 #[test]
 fn for_with_literals_statement() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         FOR y := x TO 10 DO
@@ -173,7 +173,7 @@ fn for_with_literals_statement() {
 
 #[test]
 fn for_with_step_statement() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         FOR x := 1 TO 10 BY 7 DO 
@@ -209,7 +209,7 @@ fn for_with_step_statement() {
 
 #[test]
 fn for_with_reference_statement() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         FOR z := x TO y DO
@@ -241,7 +241,7 @@ fn for_with_reference_statement() {
 
 #[test]
 fn for_with_body_statement() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         FOR z := x TO y DO
@@ -282,7 +282,7 @@ fn for_with_body_statement() {
 
 #[test]
 fn while_with_literal() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         WHILE TRUE DO
@@ -307,7 +307,7 @@ fn while_with_literal() {
 
 #[test]
 fn while_with_expression() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         WHILE x < 7 DO 
@@ -338,7 +338,7 @@ fn while_with_expression() {
 
 #[test]
 fn while_with_body_statement() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         WHILE TRUE DO
@@ -373,7 +373,7 @@ fn while_with_body_statement() {
 
 #[test]
 fn repeat_with_literal() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         REPEAT
@@ -399,7 +399,7 @@ fn repeat_with_literal() {
 
 #[test]
 fn repeat_with_expression() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         REPEAT
@@ -431,7 +431,7 @@ fn repeat_with_expression() {
 
 #[test]
 fn repeat_with_body_statement() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         REPEAT
@@ -467,7 +467,7 @@ fn repeat_with_body_statement() {
 
 #[test]
 fn case_statement_with_one_condition() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         CASE StateMachine OF
@@ -506,7 +506,7 @@ fn case_statement_with_one_condition() {
 
 #[test]
 fn case_statement_with_else_and_no_condition() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         CASE StateMachine OF
@@ -534,7 +534,7 @@ fn case_statement_with_else_and_no_condition() {
 
 #[test]
 fn case_statement_with_no_conditions() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         CASE StateMachine OF
@@ -561,7 +561,7 @@ fn case_statement_with_no_conditions() {
 
 #[test]
 fn case_statement_with_one_condition_and_an_else() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         CASE StateMachine OF
@@ -606,7 +606,7 @@ fn case_statement_with_one_condition_and_an_else() {
 
 #[test]
 fn case_statement_with_one_empty_condition_and_an_else() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         CASE StateMachine OF
@@ -647,7 +647,7 @@ fn case_statement_with_one_empty_condition_and_an_else() {
 
 #[test]
 fn case_statement_with_multiple_conditions() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         CASE StateMachine OF
@@ -714,7 +714,7 @@ fn case_statement_with_multiple_conditions() {
 
 #[test]
 fn case_statement_with_multiple_expressions_per_condition() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         CASE StateMachine OF
@@ -795,14 +795,14 @@ fn if_stmnt_location_test() {
     END_IF
     END_PROGRAM";
 
-    let lexer = lexer::lex(source);
+    let lexer = super::lex(source);
     let parse_result = parse(lexer).unwrap().0;
 
     let unit = &parse_result.implementations[0];
 
     let location = &unit.statements[0].get_location();
     assert_eq!(
-        source[location.start..location.end].to_string(),
+        source[location.get_start()..location.get_end()].to_string(),
         "IF a > 4 THEN
         a + b;
     ELSIF x < 2 THEN
@@ -813,13 +813,13 @@ fn if_stmnt_location_test() {
     if let Statement::IfStatement { blocks, .. } = &unit.statements[0] {
         let if_location = blocks[0].condition.as_ref().get_location();
         assert_eq!(
-            source[if_location.start..if_location.end].to_string(),
+            source[if_location.get_start()..if_location.get_end()].to_string(),
             "a > 4"
         );
 
         let elsif_location = blocks[1].condition.as_ref().get_location();
         assert_eq!(
-            source[elsif_location.start..elsif_location.end].to_string(),
+            source[elsif_location.get_start()..elsif_location.get_end()].to_string(),
             "x < 2"
         );
     }
@@ -834,14 +834,14 @@ fn for_stmnt_location_test() {
     END_FOR
     END_PROGRAM";
 
-    let lexer = lexer::lex(source);
+    let lexer = super::lex(source);
     let parse_result = parse(lexer).unwrap().0;
 
     let unit = &parse_result.implementations[0];
 
     let location = &unit.statements[0].get_location();
     assert_eq!(
-        source[location.start..location.end].to_string(),
+        source[location.get_start()..location.get_end()].to_string(),
         "FOR x := 3 TO 9 BY 2 DO
         a + b;
     END_FOR"
@@ -857,19 +857,19 @@ fn for_stmnt_location_test() {
     {
         let counter_location = counter.as_ref().get_location();
         assert_eq!(
-            source[counter_location.start..counter_location.end].to_string(),
+            source[counter_location.get_start()..counter_location.get_end()].to_string(),
             "x"
         );
 
         let start_location = start.as_ref().get_location();
         assert_eq!(
-            source[start_location.start..start_location.end].to_string(),
+            source[start_location.get_start()..start_location.get_end()].to_string(),
             "3"
         );
 
         let end_location = end.as_ref().get_location();
         assert_eq!(
-            source[end_location.start..end_location.end].to_string(),
+            source[end_location.get_start()..end_location.get_end()].to_string(),
             "9"
         );
 
@@ -877,7 +877,10 @@ fn for_stmnt_location_test() {
             .as_ref()
             .map(|it| it.as_ref().get_location())
             .unwrap();
-        assert_eq!(source[by_location.start..by_location.end].to_string(), "2");
+        assert_eq!(
+            source[by_location.get_start()..by_location.get_end()].to_string(),
+            "2"
+        );
     } else {
         panic!("expected ForLoopStatement")
     }
@@ -892,14 +895,14 @@ fn while_stmnt_location_test() {
     END_WHILE
     END_PROGRAM";
 
-    let lexer = lexer::lex(source);
+    let lexer = super::lex(source);
     let parse_result = parse(lexer).unwrap().0;
 
     let unit = &parse_result.implementations[0];
 
     let location = &unit.statements[0].get_location();
     assert_eq!(
-        source[location.start..location.end].to_string(),
+        source[location.get_start()..location.get_end()].to_string(),
         "WHILE a < 2 DO
         a := a - 1;
     END_WHILE"
@@ -918,14 +921,14 @@ fn case_stmnt_location_test() {
     END_CASE
     END_PROGRAM";
 
-    let lexer = lexer::lex(source);
+    let lexer = super::lex(source);
     let parse_result = parse(lexer).unwrap().0;
 
     let unit = &parse_result.implementations[0];
 
     let location = &unit.statements[0].get_location();
     assert_eq!(
-        source[location.start..location.end].to_string(),
+        source[location.get_start()..location.get_end()].to_string(),
         "CASE a OF
     1:
         a := a - 1;
@@ -942,14 +945,14 @@ fn call_stmnt_location_test() {
     foo(a:=3, b:=4);
     END_PROGRAM";
 
-    let lexer = lexer::lex(source);
+    let lexer = super::lex(source);
     let parse_result = parse(lexer).unwrap().0;
 
     let unit = &parse_result.implementations[0];
 
     let location = &unit.statements[0].get_location();
     assert_eq!(
-        source[location.start..location.end].to_string(),
+        source[location.get_start()..location.get_end()].to_string(),
         "foo(a:=3, b:=4)"
     );
 
@@ -961,14 +964,14 @@ fn call_stmnt_location_test() {
     {
         let operator_location = operator.as_ref().get_location();
         assert_eq!(
-            source[operator_location.start..operator_location.end].to_string(),
+            source[operator_location.get_start()..operator_location.get_end()].to_string(),
             "foo"
         );
 
         let parameters_statement = parameters.as_ref().as_ref();
         let parameters_location = parameters_statement.map(|it| it.get_location()).unwrap();
         assert_eq!(
-            source[parameters_location.start..parameters_location.end].to_string(),
+            source[parameters_location.get_start()..parameters_location.get_end()].to_string(),
             "a:=3, b:=4"
         );
     }

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1,14 +1,11 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use crate::ast::{Operator, Statement};
 use crate::parser::parse;
-use crate::{
-    ast::{Operator, Statement},
-    lexer,
-};
 use pretty_assertions::*;
 
 #[test]
 fn single_statement_parsed() {
-    let lexer = lexer::lex("PROGRAM exp x; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp x; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -23,7 +20,7 @@ fn single_statement_parsed() {
 
 #[test]
 fn qualified_reference_statement_parsed() {
-    let lexer = lexer::lex("PROGRAM exp a.x; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp a.x; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -35,11 +32,11 @@ fn qualified_reference_statement_parsed() {
             &[
                 Statement::Reference {
                     name: "a".to_string(),
-                    location: 12..13
+                    location: (12..13).into()
                 },
                 Statement::Reference {
                     name: "x".to_string(),
-                    location: 14..15
+                    location: (14..15).into()
                 },
             ]
         );
@@ -50,7 +47,7 @@ fn qualified_reference_statement_parsed() {
 
 #[test]
 fn literal_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM exp 7; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp 7; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -65,7 +62,7 @@ fn literal_can_be_parsed() {
 
 #[test]
 fn additon_of_two_variables_parsed() {
-    let lexer = lexer::lex("PROGRAM exp x+y; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp x+y; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -91,7 +88,7 @@ fn additon_of_two_variables_parsed() {
 
 #[test]
 fn additon_of_three_variables_parsed() {
-    let lexer = lexer::lex("PROGRAM exp x+y-z; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp x+y-z; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -130,7 +127,7 @@ fn additon_of_three_variables_parsed() {
 
 #[test]
 fn parenthesis_expressions_should_not_change_the_ast() {
-    let lexer = lexer::lex("PROGRAM exp (x+y); END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp (x+y); END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -156,7 +153,7 @@ fn parenthesis_expressions_should_not_change_the_ast() {
 
 #[test]
 fn multiplication_expressions_parse() {
-    let lexer = lexer::lex("PROGRAM exp 1*2/7; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp 1*2/7; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -183,7 +180,7 @@ fn multiplication_expressions_parse() {
 
 #[test]
 fn addition_ast_test() {
-    let lexer = lexer::lex("PROGRAM exp 1+2; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp 1+2; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -204,7 +201,7 @@ fn addition_ast_test() {
 
 #[test]
 fn multiplication_ast_test() {
-    let lexer = lexer::lex("PROGRAM exp 1+2*3; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp 1+2*3; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -231,7 +228,7 @@ fn multiplication_ast_test() {
 
 #[test]
 fn term_ast_test() {
-    let lexer = lexer::lex("PROGRAM exp 1+2*3+4; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp 1+2*3+4; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -264,7 +261,7 @@ fn term_ast_test() {
 
 #[test]
 fn module_expression_test() {
-    let lexer = lexer::lex("PROGRAM exp 5 MOD 2; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp 5 MOD 2; END_PROGRAM");
 
     let result = parse(lexer).unwrap().0;
 
@@ -287,7 +284,7 @@ fn module_expression_test() {
 
 #[test]
 fn parenthesized_term_ast_test() {
-    let lexer = lexer::lex("PROGRAM exp (1+2)*(3+4); END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp (1+2)*(3+4); END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -320,7 +317,7 @@ fn parenthesized_term_ast_test() {
 
 #[test]
 fn boolean_literals_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM exp TRUE OR FALSE; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp TRUE OR FALSE; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -341,7 +338,7 @@ fn boolean_literals_can_be_parsed() {
 
 #[test]
 fn assignment_test() {
-    let lexer = lexer::lex("PROGRAM exp x := 3; x := 1 + 2; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp x := 3; x := 1 + 2; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -382,7 +379,7 @@ fn assignment_test() {
 
 #[test]
 fn equality_expression_test() {
-    let lexer = lexer::lex("PROGRAM exp x = 3; x - 0 <> 1 + 2; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp x = 3; x - 0 <> 1 + 2; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -430,7 +427,7 @@ fn equality_expression_test() {
 }
 #[test]
 fn comparison_expression_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "PROGRAM exp 
                                     a < 3; 
                                     b > 0;
@@ -529,7 +526,7 @@ fn comparison_expression_test() {
 
 #[test]
 fn boolean_expression_ast_test() {
-    let lexer = lexer::lex("PROGRAM exp a AND NOT b OR c XOR d; END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp a AND NOT b OR c XOR d; END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -565,7 +562,7 @@ fn boolean_expression_ast_test() {
 
 #[test]
 fn boolean_expression_param_ast_test() {
-    let lexer = lexer::lex("PROGRAM exp a AND (NOT (b OR c) XOR d); END_PROGRAM");
+    let lexer = super::lex("PROGRAM exp a AND (NOT (b OR c) XOR d); END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -601,7 +598,7 @@ fn boolean_expression_param_ast_test() {
 
 #[test]
 fn signed_literal_minus_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         -1;
@@ -625,7 +622,7 @@ fn signed_literal_minus_test() {
 
 #[test]
 fn literal_real_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         1.1;
@@ -663,7 +660,7 @@ fn literal_real_test() {
 
 #[test]
 fn signed_literal_expression_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         2 +-x;
@@ -693,7 +690,7 @@ fn signed_literal_expression_test() {
 
 #[test]
 fn signed_literal_expression_reversed_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         -4 + 5;
@@ -723,7 +720,7 @@ fn signed_literal_expression_reversed_test() {
 
 #[test]
 fn or_compare_expressions_priority_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         x > 1 OR b1;
@@ -756,7 +753,7 @@ fn or_compare_expressions_priority_test() {
 
 #[test]
 fn addition_compare_or_priority_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         x + 1 > 2 OR b1;
@@ -795,7 +792,7 @@ fn addition_compare_or_priority_test() {
 
 #[test]
 fn boolean_priority_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         a AND b XOR c OR d;
@@ -834,7 +831,7 @@ fn boolean_priority_test() {
 
 #[test]
 fn comparison_priority_test() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         x < 7 = y > 6;
@@ -874,7 +871,7 @@ fn comparison_priority_test() {
 #[test]
 fn expression_list() {
     //technically this is an illegal state, the parser will accept it though
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         1,2,3;
@@ -906,7 +903,7 @@ fn expression_list() {
 #[test]
 fn expression_list_assignments() {
     //technically this is an illegal state, the parser will accept it though
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         x := 1, y := 2, z:= 3;
@@ -952,7 +949,7 @@ fn expression_list_assignments() {
 
 #[test]
 fn range_expression() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         a..b;
@@ -1021,7 +1018,7 @@ fn range_expression() {
 
 #[test]
 fn negative_range_expression() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         -2..-1;
@@ -1054,7 +1051,7 @@ fn negative_range_expression() {
 
 #[test]
 fn negative_range_expression_space() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         -2 ..-1;
@@ -1087,7 +1084,7 @@ fn negative_range_expression_space() {
 
 #[test]
 fn range_expression2() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM exp 
         1 .. 2;
@@ -1113,7 +1110,7 @@ fn range_expression2() {
 
 #[test]
 fn function_call_no_params() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
     PROGRAM prg
     fn();
@@ -1138,7 +1135,7 @@ fn function_call_no_params() {
 
 #[test]
 fn function_call_params() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
     PROGRAM prg
     fn(1,2,3);
@@ -1177,7 +1174,7 @@ fn function_call_params() {
 
 #[test]
 fn string_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "PROGRAM buz VAR x : STRING; END_VAR x := 'Hello, World!'; x := ''; END_PROGRAM",
     );
     let result = parse(lexer).unwrap().0;
@@ -1229,7 +1226,7 @@ fn string_can_be_parsed() {
 
 #[test]
 fn arrays_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "PROGRAM buz VAR x : ARRAY[0..9] OF STRING; END_VAR x[0] := 'Hello, World!'; x[y] := ''; END_PROGRAM",
     );
     let result = parse(lexer).unwrap().0;
@@ -1304,7 +1301,7 @@ fn arrays_can_be_parsed() {
 
 #[test]
 fn nested_arrays_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "PROGRAM buz VAR x : ARRAY[0..9] OF ARRAY[0..9] OF STRING; END_VAR x[0][1] := 'Hello, World!'; x[y][1] := ''; END_PROGRAM",
     );
     let result = parse(lexer).unwrap().0;
@@ -1402,7 +1399,7 @@ fn nested_arrays_can_be_parsed() {
 
 #[test]
 fn multidim_arrays_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "PROGRAM buz VAR x : ARRAY[0..9,1..2] OF STRING; END_VAR x[0,1] := 'Hello, World!'; x[y,1] := ''; END_PROGRAM",
     );
     let result = parse(lexer).unwrap().0;
@@ -1503,7 +1500,7 @@ fn multidim_arrays_can_be_parsed() {
 
 #[test]
 fn arrays_in_structs_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM buz VAR x : MyStructWithArray; END_VAR x.y[7]; END_PROGRAM",
     );
@@ -1533,7 +1530,7 @@ fn arrays_in_structs_can_be_parsed() {
 
 #[test]
 fn arrays_of_structs_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
         PROGRAM buz VAR x : ARRAY[0..1] OF MyStruct; END_VAR x[1].y; END_PROGRAM",
     );
@@ -1563,7 +1560,7 @@ fn arrays_of_structs_can_be_parsed() {
 
 #[test]
 fn function_call_formal_params() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
     PROGRAM prg
     fn(x := 1,y := 2,z => a);
@@ -1617,7 +1614,7 @@ fn function_call_formal_params() {
 
 #[test]
 fn function_call_return_params() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
     PROGRAM prg
     x := fn(1,2,3);
@@ -1662,48 +1659,69 @@ fn function_call_return_params() {
 #[test]
 fn literals_location_test() {
     let source = "PROGRAM prg 7; 'hello'; TRUE; 3.1415; END_PROGRAM";
-    let lexer = lexer::lex(source);
+    let lexer = super::lex(source);
     let parse_result = parse(lexer).unwrap().0;
 
     let unit = &parse_result.implementations[0];
 
     // 1
     let location = &unit.statements[0].get_location();
-    assert_eq!(location, &(12..13));
-    assert_eq!(source[location.start..location.end].to_string(), "7");
+    assert_eq!(location, &(12..13).into());
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "7"
+    );
 
     // 'hello'
     let location = &unit.statements[1].get_location();
-    assert_eq!(location, &(15..22));
-    assert_eq!(source[location.start..location.end].to_string(), "'hello'");
+    assert_eq!(location, &(15..22).into());
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "'hello'"
+    );
 
     // true
     let location = &unit.statements[2].get_location();
-    assert_eq!(location, &(24..28));
-    assert_eq!(source[location.start..location.end].to_string(), "TRUE");
+    assert_eq!(location, &(24..28).into());
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "TRUE"
+    );
 
     //3.1415
     let location = &unit.statements[3].get_location();
-    assert_eq!(location, &(30..36));
-    assert_eq!(source[location.start..location.end].to_string(), "3.1415")
+    assert_eq!(location, &(30..36).into());
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "3.1415"
+    )
 }
 
 #[test]
 fn reference_location_test() {
     let source = "PROGRAM prg a;bb;ccc; END_PROGRAM";
-    let lexer = lexer::lex(source);
+    let lexer = super::lex(source);
     let parse_result = parse(lexer).unwrap().0;
 
     let unit = &parse_result.implementations[0];
 
     let location = &unit.statements[0].get_location();
-    assert_eq!(source[location.start..location.end].to_string(), "a");
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "a"
+    );
 
     let location = &unit.statements[1].get_location();
-    assert_eq!(source[location.start..location.end].to_string(), "bb");
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "bb"
+    );
 
     let location = &unit.statements[2].get_location();
-    assert_eq!(source[location.start..location.end].to_string(), "ccc");
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "ccc"
+    );
 }
 
 #[test]
@@ -1716,29 +1734,38 @@ fn expressions_location_test() {
         1..3;
         a := a + 4;
     END_PROGRAM";
-    let lexer = lexer::lex(source);
+    let lexer = super::lex(source);
     let parse_result = parse(lexer).unwrap().0;
 
     let unit = &parse_result.implementations[0];
 
     let location = &unit.statements[0].get_location();
-    assert_eq!(source[location.start..location.end].to_string(), "a + b");
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "a + b"
+    );
 
     let location = &unit.statements[1].get_location();
     assert_eq!(
-        source[location.start..location.end].to_string(),
+        source[location.get_start()..location.get_end()].to_string(),
         "x + z - y + u - v"
     );
 
     let location = &unit.statements[2].get_location();
-    assert_eq!(source[location.start..location.end].to_string(), "-x");
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "-x"
+    );
 
     let location = &unit.statements[3].get_location();
-    assert_eq!(source[location.start..location.end].to_string(), "1..3");
+    assert_eq!(
+        source[location.get_start()..location.get_end()].to_string(),
+        "1..3"
+    );
 
     let location = &unit.statements[4].get_location();
     assert_eq!(
-        source[location.start..location.end].to_string(),
+        source[location.get_start()..location.get_end()].to_string(),
         "a := a + 4"
     );
 }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -6,13 +6,13 @@ use pretty_assertions::*;
 
 #[test]
 fn empty_returns_empty_compilation_unit() {
-    let (result, _) = parse(lexer::lex("")).unwrap();
+    let (result, _) = parse(super::lex("")).unwrap();
     assert_eq!(result.units.len(), 0);
 }
 
 #[test]
 fn empty_global_vars_can_be_parsed() {
-    let lexer = lexer::lex("VAR_GLOBAL END_VAR");
+    let lexer = super::lex("VAR_GLOBAL END_VAR");
     let result = parse(lexer).unwrap().0;
 
     let vars = &result.global_vars[0]; //globar_vars
@@ -26,7 +26,7 @@ fn empty_global_vars_can_be_parsed() {
 
 #[test]
 fn global_vars_can_be_parsed() {
-    let lexer = lexer::lex("VAR_GLOBAL x : INT; y : BOOL; END_VAR");
+    let lexer = super::lex("VAR_GLOBAL x : INT; y : BOOL; END_VAR");
     let result = parse(lexer).unwrap().0;
 
     let vars = &result.global_vars[0]; //globar_vars
@@ -53,7 +53,7 @@ fn global_vars_can_be_parsed() {
 
 #[test]
 fn two_global_vars_can_be_parsed() {
-    let lexer = lexer::lex("VAR_GLOBAL a: INT; END_VAR VAR_GLOBAL x : INT; y : BOOL; END_VAR");
+    let lexer = super::lex("VAR_GLOBAL a: INT; END_VAR VAR_GLOBAL x : INT; y : BOOL; END_VAR");
     let result = parse(lexer).unwrap().0;
 
     let vars = &result.global_vars; //globar_vars
@@ -93,7 +93,7 @@ fn two_global_vars_can_be_parsed() {
 
 #[test]
 fn simple_foo_program_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM foo END_PROGRAM");
+    let lexer = super::lex("PROGRAM foo END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -104,7 +104,7 @@ fn simple_foo_program_can_be_parsed() {
 
 #[test]
 fn simple_foo_function_can_be_parsed() {
-    let lexer = lexer::lex("FUNCTION foo : INT END_FUNCTION");
+    let lexer = super::lex("FUNCTION foo : INT END_FUNCTION");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -120,7 +120,7 @@ fn simple_foo_function_can_be_parsed() {
 
 #[test]
 fn simple_foo_function_block_can_be_parsed() {
-    let lexer = lexer::lex("FUNCTION_BLOCK foo END_FUNCTION_BLOCK");
+    let lexer = super::lex("FUNCTION_BLOCK foo END_FUNCTION_BLOCK");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -131,7 +131,7 @@ fn simple_foo_function_block_can_be_parsed() {
 
 #[test]
 fn single_action_parsed() {
-    let lexer = lexer::lex("ACTION foo.bar END_ACTION");
+    let lexer = super::lex("ACTION foo.bar END_ACTION");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -141,7 +141,7 @@ fn single_action_parsed() {
 
 #[test]
 fn two_actions_parsed() {
-    let lexer = lexer::lex("ACTION foo.bar END_ACTION ACTION fuz.bar END_ACTION");
+    let lexer = super::lex("ACTION foo.bar END_ACTION ACTION fuz.bar END_ACTION");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -155,7 +155,7 @@ fn two_actions_parsed() {
 
 #[test]
 fn action_container_parsed() {
-    let lexer = lexer::lex("ACTIONS foo ACTION bar END_ACTION END_ACTIONS");
+    let lexer = super::lex("ACTIONS foo ACTION bar END_ACTION END_ACTIONS");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -165,7 +165,7 @@ fn action_container_parsed() {
 
 #[test]
 fn two_action_containers_parsed() {
-    let lexer = lexer::lex("ACTIONS foo ACTION bar END_ACTION ACTION buz END_ACTION END_ACTIONS");
+    let lexer = super::lex("ACTIONS foo ACTION bar END_ACTION ACTION buz END_ACTION END_ACTIONS");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -179,7 +179,7 @@ fn two_action_containers_parsed() {
 
 #[test]
 fn mixed_action_types_parsed() {
-    let lexer = lexer::lex("PROGRAM foo END_PROGRAM ACTIONS foo ACTION bar END_ACTION END_ACTIONS ACTION foo.buz END_ACTION");
+    let lexer = super::lex("PROGRAM foo END_PROGRAM ACTIONS foo ACTION bar END_ACTION END_ACTIONS ACTION foo.buz END_ACTION");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[1];
@@ -193,7 +193,7 @@ fn mixed_action_types_parsed() {
 
 #[test]
 fn actions_with_no_container_error() {
-    let lexer = lexer::lex("ACTIONS ACTION bar END_ACTION ACTION buz END_ACTION END_ACTIONS");
+    let lexer = super::lex("ACTIONS ACTION bar END_ACTION ACTION buz END_ACTION END_ACTIONS");
     let err = parse(lexer).expect_err("Expecting parser failure");
     assert_eq!(
         err,
@@ -204,7 +204,7 @@ fn actions_with_no_container_error() {
 
 #[test]
 fn two_programs_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM foo END_PROGRAM  PROGRAM bar END_PROGRAM");
+    let lexer = super::lex("PROGRAM foo END_PROGRAM  PROGRAM bar END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -215,7 +215,7 @@ fn two_programs_can_be_parsed() {
 
 #[test]
 fn simple_program_with_varblock_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM buz VAR END_VAR END_PROGRAM");
+    let lexer = super::lex("PROGRAM buz VAR END_VAR END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -225,7 +225,7 @@ fn simple_program_with_varblock_can_be_parsed() {
 
 #[test]
 fn simple_program_with_two_varblocks_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM buz VAR END_VAR VAR END_VAR END_PROGRAM");
+    let lexer = super::lex("PROGRAM buz VAR END_VAR VAR END_VAR END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -235,7 +235,7 @@ fn simple_program_with_two_varblocks_can_be_parsed() {
 
 #[test]
 fn a_program_needs_to_end_with_end_program() {
-    let lexer = lexer::lex("PROGRAM buz ");
+    let lexer = super::lex("PROGRAM buz ");
     let result = parse(lexer);
     assert_eq!(
         result,
@@ -248,7 +248,7 @@ fn a_program_needs_to_end_with_end_program() {
 
 #[test]
 fn a_variable_declaration_block_needs_to_end_with_endvar() {
-    let lexer = lexer::lex("PROGRAM buz VAR END_PROGRAM ");
+    let lexer = super::lex("PROGRAM buz VAR END_PROGRAM ");
     let result = parse(lexer);
     assert_eq!(
         result,
@@ -258,7 +258,7 @@ fn a_variable_declaration_block_needs_to_end_with_endvar() {
 
 #[test]
 fn a_statement_without_a_semicolon_fails() {
-    let lexer = lexer::lex("PROGRAM buz x END_PROGRAM ");
+    let lexer = super::lex("PROGRAM buz x END_PROGRAM ");
     let result = parse(lexer);
     assert_eq!(
         result,
@@ -268,7 +268,7 @@ fn a_statement_without_a_semicolon_fails() {
 
 #[test]
 fn empty_statements_are_ignored() {
-    let lexer = lexer::lex("PROGRAM buz ;;;; END_PROGRAM ");
+    let lexer = super::lex("PROGRAM buz ;;;; END_PROGRAM ");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -277,7 +277,7 @@ fn empty_statements_are_ignored() {
 
 #[test]
 fn empty_statements_are_ignored_before_a_statement() {
-    let lexer = lexer::lex("PROGRAM buz ;;;;x; END_PROGRAM ");
+    let lexer = super::lex("PROGRAM buz ;;;;x; END_PROGRAM ");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -292,7 +292,7 @@ fn empty_statements_are_ignored_before_a_statement() {
 
 #[test]
 fn empty_statements_are_ignored_after_a_statement() {
-    let lexer = lexer::lex("PROGRAM buz x;;;; END_PROGRAM ");
+    let lexer = super::lex("PROGRAM buz x;;;; END_PROGRAM ");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.implementations[0];
@@ -307,7 +307,7 @@ fn empty_statements_are_ignored_after_a_statement() {
 
 #[test]
 fn simple_program_with_variable_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM buz VAR x : INT; END_VAR END_PROGRAM");
+    let lexer = super::lex("PROGRAM buz VAR x : INT; END_VAR END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -329,7 +329,7 @@ fn simple_program_with_variable_can_be_parsed() {
 
 #[test]
 fn simple_program_with_var_input_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM buz VAR_INPUT x : INT; END_VAR END_PROGRAM");
+    let lexer = super::lex("PROGRAM buz VAR_INPUT x : INT; END_VAR END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -351,7 +351,7 @@ fn simple_program_with_var_input_can_be_parsed() {
 
 #[test]
 fn simple_program_with_var_output_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM buz VAR_OUTPUT x : INT; END_VAR END_PROGRAM");
+    let lexer = super::lex("PROGRAM buz VAR_OUTPUT x : INT; END_VAR END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -373,7 +373,7 @@ fn simple_program_with_var_output_can_be_parsed() {
 
 #[test]
 fn simple_program_with_var_inout_can_be_parsed() {
-    let lexer = lexer::lex("PROGRAM buz VAR_IN_OUT x : INT; END_VAR END_PROGRAM");
+    let lexer = super::lex("PROGRAM buz VAR_IN_OUT x : INT; END_VAR END_PROGRAM");
     let result = parse(lexer).unwrap().0;
 
     let prg = &result.units[0];
@@ -395,7 +395,7 @@ fn simple_program_with_var_inout_can_be_parsed() {
 
 #[test]
 fn simple_struct_type_can_be_parsed() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
         TYPE SampleStruct :
             STRUCT
@@ -422,7 +422,7 @@ fn simple_struct_type_can_be_parsed() {
                             referenced_type: "INT".to_string(),
                         },
                         initializer: None,
-                        location: 0..0,
+                        location: SourceRange::undefined(),
                     },
                     Variable {
                         name: "Two".to_string(),
@@ -430,7 +430,7 @@ fn simple_struct_type_can_be_parsed() {
                             referenced_type: "INT".to_string(),
                         },
                         initializer: None,
-                        location: 0..0,
+                        location: SourceRange::undefined(),
                     },
                     Variable {
                         name: "Three".to_string(),
@@ -438,7 +438,7 @@ fn simple_struct_type_can_be_parsed() {
                             referenced_type: "INT".to_string(),
                         },
                         initializer: None,
-                        location: 0..0,
+                        location: SourceRange::undefined(),
                     },
                 ),
             },
@@ -450,7 +450,7 @@ fn simple_struct_type_can_be_parsed() {
 
 #[test]
 fn struct_with_inline_array_can_be_parsed() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
         TYPE SampleStruct :
             STRUCT
@@ -497,7 +497,7 @@ fn struct_with_inline_array_can_be_parsed() {
 
 #[test]
 fn simple_enum_type_can_be_parsed() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
         TYPE SampleEnum : (red, yellow, green);
         END_TYPE 
@@ -520,7 +520,7 @@ fn simple_enum_type_can_be_parsed() {
 
 #[test]
 fn type_alias_can_be_parsed() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
         TYPE 
             MyInt : INT;
@@ -547,7 +547,7 @@ fn type_alias_can_be_parsed() {
 
 #[test]
 fn array_type_can_be_parsed_test() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
             TYPE MyArray : ARRAY[0..8] OF INT; END_TYPE
             "#,
@@ -564,11 +564,11 @@ fn array_type_can_be_parsed_test() {
                 bounds: Statement::RangeStatement {
                     start: Box::new(Statement::LiteralInteger {
                         value: "0".to_string(),
-                        location: 0..0,
+                        location: SourceRange::undefined(),
                     }),
                     end: Box::new(Statement::LiteralInteger {
                         value: "8".to_string(),
-                        location: 0..0,
+                        location: SourceRange::undefined(),
                     }),
                 },
                 referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
@@ -584,7 +584,7 @@ fn array_type_can_be_parsed_test() {
 
 #[test]
 fn string_type_can_be_parsed_test() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
             TYPE MyString : STRING[253]; END_TYPE
             "#,
@@ -600,7 +600,7 @@ fn string_type_can_be_parsed_test() {
                 name: Some("MyString".to_string()),
                 size: Some(LiteralInteger {
                     value: "253".to_string(),
-                    location: 10..11,
+                    location: (10..11).into(),
                 }),
                 is_wide: false,
             },
@@ -613,7 +613,7 @@ fn string_type_can_be_parsed_test() {
 
 #[test]
 fn array_type_initialization_with_literals_can_be_parsed_test() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
             TYPE MyArray : ARRAY[0..2] OF INT := [1,2,3]; END_TYPE
             "#,
@@ -647,7 +647,7 @@ fn array_type_initialization_with_literals_can_be_parsed_test() {
 
 #[test]
 fn array_initializer_in_pou_can_be_parsed() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
             PROGRAM main
             VAR
@@ -686,7 +686,7 @@ fn array_initializer_in_pou_can_be_parsed() {
 
 #[test]
 fn inline_struct_declaration_can_be_parsed() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
         VAR_GLOBAL
             my_struct : STRUCT
@@ -734,7 +734,7 @@ fn inline_struct_declaration_can_be_parsed() {
 
 #[test]
 fn inline_enum_declaration_can_be_parsed() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
         VAR_GLOBAL
             my_enum : (red, yellow, green);
@@ -754,7 +754,7 @@ fn inline_enum_declaration_can_be_parsed() {
             },
         },
         initializer: None,
-        location: 0..0,
+        location: SourceRange::undefined(),
     };
     let expected_ast = format!("{:#?}", &v);
     assert_eq!(ast_string, expected_ast);
@@ -762,7 +762,7 @@ fn inline_enum_declaration_can_be_parsed() {
 
 #[test]
 fn multilevel_inline_struct_and_enum_declaration_can_be_parsed() {
-    let (result, _) = parse(lexer::lex(
+    let (result, _) = parse(super::lex(
         r#"
         VAR_GLOBAL
             my_struct : STRUCT
@@ -822,7 +822,7 @@ fn multilevel_inline_struct_and_enum_declaration_can_be_parsed() {
 
 #[test]
 fn test_ast_line_locations() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "PROGRAM prg
                 call1();
 
@@ -838,22 +838,22 @@ fn test_ast_line_locations() {
     let statements = &parse_result.implementations[0].statements;
 
     {
-        let statement_offset = statements.get(0).unwrap().get_location().start;
+        let statement_offset = statements.get(0).unwrap().get_location().get_start();
         let line = new_lines.get_line_of(statement_offset).unwrap();
         assert_eq!(2, line);
     }
     {
-        let statement_offset = statements.get(1).unwrap().get_location().start;
+        let statement_offset = statements.get(1).unwrap().get_location().get_start();
         let line = new_lines.get_line_of(statement_offset).unwrap();
         assert_eq!(4, line);
     }
     {
-        let statement_offset = statements.get(2).unwrap().get_location().start;
+        let statement_offset = statements.get(2).unwrap().get_location().get_start();
         let line = new_lines.get_line_of(statement_offset).unwrap();
         assert_eq!(5, line);
     }
     {
-        let statement_offset = statements.get(3).unwrap().get_location().start;
+        let statement_offset = statements.get(3).unwrap().get_location().get_start();
         let line = new_lines.get_line_of(statement_offset).unwrap();
         assert_eq!(8, line);
     }
@@ -861,7 +861,7 @@ fn test_ast_line_locations() {
 
 #[test]
 fn test_unexpected_token_error_message() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "PROGRAM prg
                 VAR ;
                 END_VAR
@@ -882,7 +882,7 @@ fn test_unexpected_token_error_message() {
 
 #[test]
 fn programs_can_be_external() {
-    let lexer = lexer::lex("@EXTERNAL PROGRAM foo END_PROGRAM");
+    let lexer = super::lex("@EXTERNAL PROGRAM foo END_PROGRAM");
     let parse_result = parse(lexer).unwrap().0;
     let implementation = &parse_result.implementations[0];
     assert_eq!(LinkageType::External, implementation.linkage);
@@ -890,7 +890,7 @@ fn programs_can_be_external() {
 
 #[test]
 fn test_unexpected_token_error_message2() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "SOME PROGRAM prg
                 VAR ;
                 END_VAR
@@ -910,7 +910,7 @@ fn test_unexpected_token_error_message2() {
 }
 #[test]
 fn test_unexpected_type_declaration_error_message() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "TYPE MyType:
                 PROGRAM
                 END_PROGRAM
@@ -928,7 +928,7 @@ fn test_unexpected_type_declaration_error_message() {
 
 #[test]
 fn test_unclosed_body_error_message() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
             
             PROGRAM My_PRG
@@ -949,7 +949,7 @@ fn test_unclosed_body_error_message() {
 
 #[test]
 fn test_case_without_condition() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "PROGRAM My_PRG
                 CASE x OF
                     1: 
@@ -973,7 +973,7 @@ fn test_case_without_condition() {
 
 #[test]
 fn initial_scalar_values_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
             VAR_GLOBAL
                 x : INT := 7;
@@ -1094,7 +1094,7 @@ fn initial_scalar_values_can_be_parsed() {
 
 #[test]
 fn array_initializer_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
             VAR_GLOBAL
                 x : ARRAY[0..2] OF INT := [7,8,9];
@@ -1146,7 +1146,7 @@ fn array_initializer_can_be_parsed() {
 
 #[test]
 fn multi_dim_array_initializer_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
             VAR_GLOBAL
                 x : MyMultiArray := [[1,2],[3,4],[5,6]];
@@ -1218,7 +1218,7 @@ fn multi_dim_array_initializer_can_be_parsed() {
 
 #[test]
 fn array_initializer_multiplier_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
             VAR_GLOBAL
                 x : ARRAY[0..2] OF INT := [3(7)];
@@ -1263,7 +1263,7 @@ fn array_initializer_multiplier_can_be_parsed() {
 
 #[test]
 fn struct_initializer_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
             VAR_GLOBAL
                 x : Point := (x := 1, y:= 2);
@@ -1305,7 +1305,7 @@ fn struct_initializer_can_be_parsed() {
 
 #[test]
 fn string_variable_declaration_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
             VAR_GLOBAL
                 x : STRING;
@@ -1347,7 +1347,7 @@ fn string_variable_declaration_can_be_parsed() {
 
 #[test]
 fn subrangetype_can_be_parsed() {
-    let lexer = lexer::lex(
+    let lexer = super::lex(
         "
             VAR_GLOBAL
                 x : UINT(0..1000);
@@ -1365,18 +1365,38 @@ fn subrangetype_can_be_parsed() {
                 bounds: Some(Statement::RangeStatement {
                     start: Box::new(LiteralInteger {
                         value: "0".to_string(),
-                        location: 0..0,
+                        location: SourceRange::undefined(),
                     }),
                     end: Box::new(LiteralInteger {
                         value: "1000".to_string(),
-                        location: 0..0,
+                        location: SourceRange::undefined(),
                     }),
                 }),
                 referenced_type: "UINT".to_string(),
             },
         },
         initializer: None,
-        location: (0..0),
+        location: (0..0).into(),
     };
     assert_eq!(format!("{:#?}", expected), format!("{:#?}", x).as_str());
+}
+
+#[test]
+fn file_location_persisted() {
+    let lexer = lexer::lex(
+        "test_file.st",
+        "
+            VAR_GLOBAL
+                x : INT;
+            END_VAR
+
+            PROGRAM prg
+            END_PROGRAM
+           ",
+    );
+    let (parse_result, _) = parse(lexer).unwrap();
+    let location = &parse_result.global_vars[0].variables[0].location;
+    assert_eq!("test_file.st", location.get_file_path());
+    let location = &parse_result.units[0].location;
+    assert_eq!("test_file.st", location.get_file_path());
 }

--- a/tests/correctness/external_functions.rs
+++ b/tests/correctness/external_functions.rs
@@ -30,7 +30,7 @@ fn test_external_function_called() {
 
     Target::initialize_native(&InitializationConfig::default()).unwrap();
     let context: Context = Context::create();
-    let code_gen = compile_module(&context, prog.to_string()).unwrap();
+    let code_gen = compile_module(&context, "external_test.st", prog.to_string()).unwrap();
     let exec_engine = code_gen
         .module
         .create_jit_execution_engine(inkwell::OptimizationLevel::None)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -44,7 +44,7 @@ macro_rules! assert_almost_eq {
 /// The string will eventually be the Stdout of the function.
 ///
 pub fn compile(context: &Context, source: String) -> ExecutionEngine {
-    let code_gen = compile_module(context, source).unwrap();
+    let code_gen = compile_module(context, "external_test.st", source).unwrap();
     code_gen
         .module
         .create_jit_execution_engine(inkwell::OptimizationLevel::None)


### PR DESCRIPTION
Preparation for multi file support

The SourceRange in the AST now also contains a file path.
If the file path is not specified (mostly tests or undefined scenarios) we use an empty one for now.