### PR TITLE
allow mulitple files in compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +405,7 @@ name = "rusty"
 version = "0.2.0"
 dependencies = [
  "chrono",
+ "glob",
  "indexmap",
  "inkwell",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1.0"
 structopt = "0.3"
 indexmap = "1.6"
 chrono = "0.4"
-
+glob = "0.3.0"
 
 [lib]
 name = "rusty"

--- a/book/src/using_rusty.md
+++ b/book/src/using_rusty.md
@@ -1,5 +1,15 @@
 # Using RuSTy
 
+`rustyc` offers a comprehensive help via the -h (--help) option. `rustyc` takes one output-format parameter and any number of input-files.
+The input files can also be written as [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)).
+
+`rustyc [OPTIONS] <input-files>... <--ir|--shared|--pic|--static|--bc>`
+
+Examples: 
+- `rustyc --ir file1.st file2.st` will compile file1.st and file2.st.
+- `rustyc --ir src/*.st` will compile all st files in the src-folder.
+- `rustyc --ir "**/*.st"` will compile all st-files in the current folder and its subfolders recursively.
+
 ## Compiling a static object
 
 ## Compiling a linkable object

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -70,6 +70,32 @@ pub struct CompilationUnit {
     pub types: Vec<UserTypeDeclaration>,
 }
 
+impl CompilationUnit {
+    /// imports all elements of the other CompilationUnit into this CompilationUnit
+    ///
+    /// this will import all global_vars, units, implementations and types. The imported
+    /// structs are moved from the other unit into this unit
+    /// # Arguments
+    /// `other` the other CompilationUnit to import the elements from.
+    pub fn import(&mut self, other: CompilationUnit) {
+        self.global_vars.extend(other.global_vars);
+        self.units.extend(other.units);
+        self.implementations.extend(other.implementations);
+        self.types.extend(other.types);
+    }
+}
+
+impl Default for CompilationUnit {
+    fn default() -> Self {
+        CompilationUnit {
+            global_vars: Vec::new(),
+            units: Vec::new(),
+            implementations: Vec::new(),
+            types: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug, Copy, PartialEq, Clone)]
 pub enum VariableBlockType {
     Local,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,15 +7,12 @@ pub fn parse_parameters(args: Vec<String>) -> Result<CompileParameters, Paramete
     CompileParameters::from_iter_safe(args)
 }
 
-#[derive(StructOpt)]
+#[derive(StructOpt, Debug)]
 #[structopt(
         group = ArgGroup::with_name("format").required(true),
         about = "IEC61131-3 Structured Text compiler powered by Rust & LLVM "
     )]
 pub struct CompileParameters {
-    #[structopt(name = "input-file", help = "Read input from <input-file>")]
-    pub input: String,
-
     #[structopt(
         short,
         long,
@@ -62,6 +59,15 @@ pub struct CompileParameters {
         help = "A target-tripple supported by LLVM"
     )]
     pub target: Option<String>,
+
+    #[structopt(
+        name = "input-files",
+        help = "Read input from <input-files>, may be a glob expression like 'src/**/*' or a sequence of files",
+        required = true,
+        min_values = 1
+    )]
+    // having a vec allows bash to resolve *.st itself
+    pub input: Vec<String>,
 }
 
 #[cfg(test)]
@@ -76,7 +82,10 @@ mod cli_tests {
             Err(ParameterError { kind, .. }) => {
                 assert_eq!(kind, expected_error_kind);
             }
-            _ => panic!("expected error, but found none. arguments: {:?}", args),
+            Ok(p) => panic!(
+                "expected error, but found none. arguments: {:?}. params: {:?}",
+                args, p
+            ),
         }
     }
     macro_rules! vec_of_strings {

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -1145,7 +1145,13 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
                 &Some(self.llvm.i64_type().into()),
                 format!(
                     "{}",
-                    calculate_time_nano(*negative, calculate_dhm_time_seconds(*day, *hour, *min, *sec), *milli, *micro, *nano)
+                    calculate_time_nano(
+                        *negative,
+                        calculate_dhm_time_seconds(*day, *hour, *min, *sec),
+                        *milli,
+                        *micro,
+                        *nano
+                    )
                 )
                 .as_str(),
             ),

--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -418,7 +418,7 @@ entry:
 }
 
 #[test]
-fn time_variables_have_nano_seconds_resolution(){
+fn time_variables_have_nano_seconds_resolution() {
     let result = codegen!(
         r#"PROGRAM prg
 VAR
@@ -452,7 +452,6 @@ entry:
 "#;
 
     assert_eq!(result, expected);
-
 }
 
 #[test]
@@ -492,7 +491,6 @@ fn date_comparisons() {
 
     assert_eq!(result, expected);
 }
-
 
 #[test]
 fn program_with_string_assignment() {

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -32,6 +32,9 @@ pub enum CompileError {
         target_type: String,
         location: SourceRange,
     },
+
+    #[error("Cannot read File {path:}: {reason:}")]
+    IoError { path: String, reason: String },
 }
 
 impl CompileError {
@@ -67,6 +70,11 @@ impl CompileError {
 
     pub fn codegen_error(message: String, location: SourceRange) -> CompileError {
         CompileError::CodeGenError { message, location }
+    }
+
+    /// creates a CompileError:IoError with the given parameters
+    pub fn io_error(path: String, reason: String) -> CompileError {
+        CompileError::IoError { path, reason }
     }
 
     pub fn no_type_associated(type_name: &str, location: SourceRange) -> CompileError {

--- a/src/index.rs
+++ b/src/index.rs
@@ -145,6 +145,19 @@ impl Index {
         }
     }
 
+    /// imports all entries from the given index into the current index
+    ///
+    /// imports all global_variables, member_variables, types and implementations
+    /// # Arguments
+    /// - `other` the other index. The elements are drained from the given index and moved
+    /// into the current one
+    pub fn import(&mut self, other: Index) {
+        self.global_variables.extend(other.global_variables);
+        self.member_variables.extend(other.member_variables);
+        self.types.extend(other.types);
+        self.implementations.extend(other.implementations);
+    }
+
     pub fn get_void_type(&self) -> &DataType {
         &self.void_type
     }
@@ -174,7 +187,6 @@ impl Index {
         })
     }
 
-    //                                     none                 ["myGlobal", "a", "b"]
     pub fn find_variable(
         &self,
         context: Option<&str>,

--- a/src/lexer/tests/lexer_tests.rs
+++ b/src/lexer/tests/lexer_tests.rs
@@ -271,12 +271,12 @@ fn date_literals_test() {
         DATE#1946 D#2001.10.04
         DATE#1946-4 D#-1-1-1
         "#);
-    for _ in 1..=2  {
+    for _ in 1..=2 {
         assert_eq!(lexer.token, LiteralDate);
         lexer.advance();
     }
 
-    for _ in 1..=4  {
+    for _ in 1..=4 {
         assert_ne!(lexer.token, LiteralDate);
         lexer.advance();
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -68,12 +68,7 @@ fn slice_and_advance(lexer: &mut RustyLexer) -> String {
 }
 
 pub fn parse(mut lexer: RustyLexer) -> Result<(CompilationUnit, NewLines), String> {
-    let mut unit = CompilationUnit {
-        global_vars: Vec::new(),
-        units: Vec::new(),
-        implementations: Vec::new(),
-        types: Vec::new(),
-    };
+    let mut unit = CompilationUnit::default();
 
     let mut linkage = LinkageType::Internal;
     loop {

--- a/tests/correctness/custom_datatypes.rs
+++ b/tests/correctness/custom_datatypes.rs
@@ -130,7 +130,6 @@ fn using_nested_structs() {
     "#;
 
     compile_and_run(testcode.to_string(), &mut main_data);
-    println!("{:?}", main_data);
     assert_eq!(11, main_data.my_s.mys1.field1);
     assert_eq!(12, main_data.my_s.mys1.field2);
     assert_eq!(13, main_data.my_s.mys1.field3);

--- a/tests/correctness/external_functions.rs
+++ b/tests/correctness/external_functions.rs
@@ -30,7 +30,11 @@ fn test_external_function_called() {
 
     Target::initialize_native(&InitializationConfig::default()).unwrap();
     let context: Context = Context::create();
-    let code_gen = compile_module(&context, "external_test.st", prog.to_string()).unwrap();
+    let source = &SourceCode {
+        path: "external_test.st".to_string(),
+        source: prog.to_string(),
+    };
+    let code_gen = compile_module(&context, &[source.as_source_container()]).unwrap();
     let exec_engine = code_gen
         .module
         .create_jit_execution_engine(inkwell::OptimizationLevel::None)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -44,7 +44,11 @@ macro_rules! assert_almost_eq {
 /// The string will eventually be the Stdout of the function.
 ///
 pub fn compile(context: &Context, source: String) -> ExecutionEngine {
-    let code_gen = compile_module(context, "external_test.st", source).unwrap();
+    let source = SourceCode {
+        path: "external_test.st".to_string(),
+        source,
+    };
+    let code_gen = compile_module(context, &[source.as_source_container()]).unwrap();
     code_gen
         .module
         .create_jit_execution_engine(inkwell::OptimizationLevel::None)


### PR DESCRIPTION
_ the cli now accepts mulitple input-files in the end.
  e.g. rustyc --ir file1.st file2.st

_ the cli now accepts glob expressions
  e.g. ./**/*.st

fixes #91