### PR TITLE
WSTRING support

### DIFF
--- a/book/src/datatypes.md
+++ b/book/src/datatypes.md
@@ -1,5 +1,34 @@
 # Datatypes
 
+## Strings
+### STRING
+rusty treats `STRING`s as byte-arrays storing UTF-8 character bytes with a Null-terminator (0-byte) at the end. 
+So a String of size n requres n+1 bytes to account for the Null-terminator.
+A `STRING` literal is surrounded by single-ticks `'`.
+
+A String has a well defined length which can be defined similar to the array-syntax. A String-variable 
+`myVariable: STRING[20]` declares a byte array of length 21, to store 20 utf8 character bytes. When 
+declaring a `STRING`, the length-attribute is optional. The default length is 80.
+
+Examples
+- `s1 : STRING;` - declares a String of length 80
+- `s2 : STRING[20];` - declares a String of length 20
+- `s3 : STRING := 'Hello World';` - declares and initializes a String of length 80, and initializes it with the utf8 characters and a null-terminator at the end
+- `s4 : STRING[55] := 'Foo Baz';` - declares and initializes a String of length 55 and initializes it with the utf8 characters and a null-terminator at the end.
+
+### WSTRING (Wide Strings)
+rusty treats `WSTRING`s as byte-arrays storing UTF-16 character bytes with two Null-terminator bytes at the end. The bytes are stored in Little Endian encoding. A Wide-String of size n requres 2 * (n+1) bytes to account for the 2 byes per utf16 character and the Null-terminators. A `WSTRING` literal is surrounded by doubly-ticks `"`.
+
+A `WSTRING` has a well defined length which can be defined similar to the array-syntax. A `WSTRING`-variable 
+`myVariable: WSTRING[20]` declares a byte array of length 42, to store 20 utf16 character bytes. When 
+declaring a `WSTRING`, the length-attribute is optional. The default length is 80.
+
+Examples
+- `ws1 : WSTRING;` - declares a Wide-String of length 80
+- `ws2 : WSTRING[20];` - declares a Wide-String of length 20
+- `ws3 : WSTRING := "Hello World";` - declares and initializes a Wide-String of length 80, and initializes it with the utf16 characters and a utf16-null-terminator at the end
+- `ws4 : WSTRING[55] := "Foo Baz";` - declares and initializes a Wide-String of length 55 and initializes it with the utf8 characters and a utf16-null-terminator at the end.
+
 ## Date and Time
 ### DATE
 The `DATE` datatype is used to represent a Date in the Gregorian Calendar. Such a value is 
@@ -7,7 +36,7 @@ stored as an i64 with a precision in milliseconds and denotes the number of mill
 that have elapsed since January 1, 1970 UTC not counting leap seconds. DATE literals start 
 with `DATE#` or `D#` followed by a date in the format of `yyyy-mm-dd`.
 
-Example literals
+Examples
 - `d1 : DATE := DATE#2021-05-02;`
 - `d2 : DATE := DATE#1-12-24;`
 - `d3 : DATE := D#2000-1-1;`
@@ -21,7 +50,7 @@ format of `yyyy-mm-dd-hh:mm:ss`.
 
 Note that only the seconds-segment can have a fraction denoting the milliseconds.
 
-Example literals
+Examples
 - `d1 : DATE_AND_TIME := DATE_AND_TIME#2021-05-02-14:20:10.25;`
 - `d2 : DATE_AND_TIME := DATE_AND_TIME#1-12-24-00:00:1;`
 - `d3 : DATE_AND_TIME := DT#1999-12-31-23:59:59.999;`
@@ -36,7 +65,7 @@ format of `hh:mm:ss`.
 
 Note that only the seconeds-segment can have a fraction denoting the milliseconds.
 
-Example literals
+Examples
 - `t1 : TIME_OF_DAY := TIME_OF_DAY#14:20:10.25;`
 - `t2 : TIME_OF_DAY := TIME_OF_DY#0:00:1;`
 - `t3 : TIME_OF_DAY := TOD#23:59:59.999;`
@@ -55,7 +84,7 @@ TIME literals start with `TIME#` or `T#` followed by the `TIME` segements. Suppo
 
 Note that only the last segment of a `TIME` literal can have a fraction.
 
-Example literals
+Examples
 - `t1 : TIME := TIME#2d4h6m8s10ms;`
 - `t2 : TIME := T#2d4.2h;`
 - `t3 : TIME := T#-10s4ms16ns;`

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -461,6 +461,7 @@ pub enum Statement {
     },
     LiteralString {
         value: String,
+        is_wide: bool,
         location: SourceRange,
     },
     LiteralArray {
@@ -623,9 +624,10 @@ impl Debug for Statement {
             Statement::LiteralBool { value, .. } => {
                 f.debug_struct("LiteralBool").field("value", value).finish()
             }
-            Statement::LiteralString { value, .. } => f
+            Statement::LiteralString { value, is_wide, .. } => f
                 .debug_struct("LiteralString")
                 .field("value", value)
+                .field("is_wide", is_wide)
                 .finish(),
             Statement::LiteralArray { elements, .. } => f
                 .debug_struct("LiteralArray")

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -128,10 +128,11 @@ fn create_type<'ink>(
         DataTypeInformation::Float { size, .. } => {
             get_llvm_float_type(llvm.context, *size, name).map(|it| it.into())
         }
-        DataTypeInformation::String { size } => {
-            let gen_type = llvm.context.i8_type().array_type(*size).into();
-            Ok(gen_type)
-        }
+        DataTypeInformation::String { size, encoding } => Ok(llvm
+            .context
+            .i8_type()
+            .array_type(*size * encoding.get_bytes_per_char())
+            .into()),
         DataTypeInformation::SubRange {
             referenced_type, ..
         } => {

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -1159,7 +1159,13 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
                 self.llvm
                     .create_const_real(self.index, &self.get_type_context(), value)
             }
-            Statement::LiteralString { value, .. } => self.llvm.create_const_string(value.as_str()),
+            Statement::LiteralString { value, is_wide, .. } => {
+                if *is_wide {
+                    self.llvm.create_const_utf16_string(value.as_str())
+                } else {
+                    self.llvm.create_const_utf8_string(value.as_str())
+                }
+            }
             Statement::LiteralArray { elements, location } => {
                 self.generate_literal_array(elements, location)
             }

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -280,13 +280,25 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 information,
             )
         }
-        DataType::StringType { name, size, .. } => {
+        DataType::StringType {
+            name,
+            size,
+            is_wide,
+            ..
+        } => {
             let size = if let Some(statement) = size {
                 evaluate_constant_int(&statement).unwrap() as u32
             } else {
                 crate::typesystem::DEFAULT_STRING_LEN // DEFAULT STRING LEN
             } + 1;
-            let information = DataTypeInformation::String { size };
+
+            let encoding = if *is_wide {
+                StringEncoding::Utf16
+            } else {
+                StringEncoding::Utf8
+            };
+
+            let information = DataTypeInformation::String { size, encoding };
             index.register_type(
                 name.as_ref().unwrap(),
                 type_declatation.initializer.clone(),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -272,6 +272,9 @@ pub enum Token {
     #[token("STRING")]
     KeywordString,
 
+    #[token("WSTRING")]
+    KeywordWideString,
+
     #[token("OF")]
     KeywordOf,
 
@@ -355,6 +358,9 @@ pub enum Token {
 
     #[regex("'((\\$.)|[^$'])*'")]
     LiteralString,
+
+    #[regex("\"((\\$.)|[^$\"])*\"")]
+    LiteralWideString,
 
     #[regex(r"[ \t\n\f]+", logos::skip)]
     End,

--- a/src/lexer/tests/lexer_tests.rs
+++ b/src/lexer/tests/lexer_tests.rs
@@ -505,3 +505,26 @@ fn string_parsing() {
     assert_eq!("'AB$''", lexer.slice());
     lexer.advance();
 }
+
+#[test]
+fn wide_string_parsing() {
+    let mut lexer = lex(r#"
+    WSTRING 
+    "AB C" 
+    "AB$$" 
+    "AB$""
+    "#);
+
+    assert_eq!(lexer.token, KeywordWideString);
+    assert_eq!("WSTRING", lexer.slice());
+    lexer.advance();
+    assert_eq!(lexer.token, LiteralWideString);
+    assert_eq!(r#""AB C""#, lexer.slice());
+    lexer.advance();
+    assert_eq!(lexer.token, LiteralWideString);
+    assert_eq!(r#""AB$$""#, lexer.slice());
+    lexer.advance();
+    assert_eq!(lexer.token, LiteralWideString);
+    assert_eq!(r#""AB$"""#, lexer.slice());
+    lexer.advance();
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -356,7 +356,8 @@ fn parse_data_type_definition(
             },
             None,
         ))
-    } else if lexer.token == KeywordString {
+    } else if lexer.token == KeywordString || lexer.token == KeywordWideString {
+        let is_wide = lexer.token == KeywordWideString;
         lexer.advance();
         let size = if allow(KeywordSquareParensOpen, lexer) {
             let size_statement = parse_expression(lexer)?;
@@ -379,7 +380,7 @@ fn parse_data_type_definition(
             DataTypeDeclaration::DataTypeDefinition {
                 data_type: DataType::StringType {
                     name,
-                    is_wide: false,
+                    is_wide,
                     size,
                 },
             },

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -217,7 +217,8 @@ fn parse_leaf_expression(lexer: &mut RustyLexer) -> Result<Statement, String> {
         LiteralTimeOfDay => parse_literal_time_of_day(lexer),
         LiteralTime => parse_literal_time(lexer),
         LiteralDateAndTime => parse_literal_date_and_time(lexer),
-        LiteralString => parse_literal_string(lexer),
+        LiteralString => parse_literal_string(lexer, false),
+        LiteralWideString => parse_literal_string(lexer, true),
         LiteralTrue => parse_bool_literal(lexer, true),
         LiteralFalse => parse_bool_literal(lexer, false),
         KeywordSquareParensOpen => parse_array_literal(lexer),
@@ -521,11 +522,12 @@ fn trim_quotes(quoted_string: &str) -> String {
     quoted_string[1..quoted_string.len() - 1].to_string()
 }
 
-fn parse_literal_string(lexer: &mut RustyLexer) -> Result<Statement, String> {
+fn parse_literal_string(lexer: &mut RustyLexer, is_wide: bool) -> Result<Statement, String> {
     let result = lexer.slice();
     let location = lexer.location();
     let string_literal = Ok(Statement::LiteralString {
         value: trim_quotes(result),
+        is_wide,
         location,
     });
     lexer.advance();

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1499,6 +1499,7 @@ fn string_can_be_parsed() {
     },
     right: LiteralString {
         value: "Hello, World!",
+        is_wide: false,
     },
 }"#;
     assert_eq!(ast_string, expected_ast);
@@ -1510,6 +1511,61 @@ fn string_can_be_parsed() {
     },
     right: LiteralString {
         value: "",
+        is_wide: false,
+    },
+}"#;
+    assert_eq!(ast_string, expected_ast);
+}
+
+#[test]
+fn wide_string_can_be_parsed() {
+    let lexer = super::lex(
+        "PROGRAM buz VAR x : WSTRING; END_VAR x := \"Hello, World!\"; x := \"\"; END_PROGRAM",
+    );
+    let result = parse(lexer).unwrap().0;
+
+    let unit = &result.units[0];
+    let prg = &result.implementations[0];
+    let variable_block = &unit.variable_blocks[0];
+    let ast_string = format!("{:#?}", variable_block);
+    let expected_ast = r#"VariableBlock {
+    variables: [
+        Variable {
+            name: "x",
+            data_type: DataTypeDefinition {
+                data_type: StringType {
+                    name: None,
+                    is_wide: true,
+                    size: None,
+                },
+            },
+        },
+    ],
+    variable_block_type: Local,
+}"#;
+    assert_eq!(ast_string, expected_ast);
+
+    let statements = &prg.statements;
+    let ast_string = format!("{:#?}", statements[0]);
+    let expected_ast = r#"Assignment {
+    left: Reference {
+        name: "x",
+    },
+    right: LiteralString {
+        value: "Hello, World!",
+        is_wide: true,
+    },
+}"#;
+    assert_eq!(ast_string, expected_ast);
+
+    let ast_string = format!("{:#?}", statements[1]);
+    let expected_ast = r#"Assignment {
+    left: Reference {
+        name: "x",
+    },
+    right: LiteralString {
+        value: "",
+        is_wide: true,
     },
 }"#;
     assert_eq!(ast_string, expected_ast);
@@ -1569,6 +1625,7 @@ fn arrays_can_be_parsed() {
     },
     right: LiteralString {
         value: "Hello, World!",
+        is_wide: false,
     },
 }"#;
     assert_eq!(ast_string, expected_ast);
@@ -1585,6 +1642,7 @@ fn arrays_can_be_parsed() {
     },
     right: LiteralString {
         value: "",
+        is_wide: false,
     },
 }"#;
     assert_eq!(ast_string, expected_ast);
@@ -1662,6 +1720,7 @@ fn nested_arrays_can_be_parsed() {
     },
     right: LiteralString {
         value: "Hello, World!",
+        is_wide: false,
     },
 }"#;
     assert_eq!(ast_string, expected_ast);
@@ -1683,6 +1742,7 @@ fn nested_arrays_can_be_parsed() {
     },
     right: LiteralString {
         value: "",
+        is_wide: false,
     },
 }"#;
     assert_eq!(ast_string, expected_ast);
@@ -1761,6 +1821,7 @@ fn multidim_arrays_can_be_parsed() {
     },
     right: LiteralString {
         value: "Hello, World!",
+        is_wide: false,
     },
 }"#;
     assert_eq!(ast_string, expected_ast);
@@ -1784,6 +1845,7 @@ fn multidim_arrays_can_be_parsed() {
     },
     right: LiteralString {
         value: "",
+        is_wide: false,
     },
 }"#;
     assert_eq!(ast_string, expected_ast);

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -612,6 +612,35 @@ fn string_type_can_be_parsed_test() {
 }
 
 #[test]
+fn wide_string_type_can_be_parsed_test() {
+    let (result, _) = parse(super::lex(
+        r#"
+            TYPE MyString : WSTRING[253]; END_TYPE
+            "#,
+    ))
+    .unwrap();
+
+    let ast_string = format!("{:#?}", &result.types[0]);
+
+    let expected_ast = format!(
+        "{:#?}",
+        &UserTypeDeclaration {
+            data_type: DataType::StringType {
+                name: Some("MyString".to_string()),
+                size: Some(LiteralInteger {
+                    value: "253".to_string(),
+                    location: (10..11).into(),
+                }),
+                is_wide: true,
+            },
+            initializer: None,
+        }
+    );
+
+    assert_eq!(ast_string, expected_ast);
+}
+
+#[test]
 fn array_type_initialization_with_literals_can_be_parsed_test() {
     let (result, _) = parse(super::lex(
         r#"
@@ -1310,6 +1339,8 @@ fn string_variable_declaration_can_be_parsed() {
             VAR_GLOBAL
                 x : STRING;
                 y : STRING[500];
+                wx : WSTRING;
+                wy : WSTRING[500];
             END_VAR
            ",
     );
@@ -1334,6 +1365,36 @@ fn string_variable_declaration_can_be_parsed() {
         data_type: StringType {
             name: None,
             is_wide: false,
+            size: Some(
+                LiteralInteger {
+                    value: "500",
+                },
+            ),
+        },
+    },
+}"#;
+    assert_eq!(expected, format!("{:#?}", x).as_str());
+
+    let x = &parse_result.global_vars[0].variables[2];
+    let expected = r#"Variable {
+    name: "wx",
+    data_type: DataTypeDefinition {
+        data_type: StringType {
+            name: None,
+            is_wide: true,
+            size: None,
+        },
+    },
+}"#;
+    assert_eq!(expected, format!("{:#?}", x).as_str());
+
+    let x = &parse_result.global_vars[0].variables[3];
+    let expected = r#"Variable {
+    name: "wy",
+    data_type: DataTypeDefinition {
+        data_type: StringType {
+            name: None,
+            is_wide: true,
             size: Some(
                 LiteralInteger {
                     value: "500",

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -35,6 +35,21 @@ impl DataType {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum StringEncoding {
+    Utf8,
+    Utf16,
+}
+
+impl StringEncoding {
+    pub fn get_bytes_per_char(&self) -> u32 {
+        match self {
+            StringEncoding::Utf8 => 1,
+            StringEncoding::Utf16 => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum DataTypeInformation {
     Struct {
         name: String,
@@ -61,6 +76,7 @@ pub enum DataTypeInformation {
     },
     String {
         size: u32,
+        encoding: StringEncoding,
     },
     SubRange {
         name: String,
@@ -300,13 +316,32 @@ pub fn get_builtin_types() -> Vec<DataType> {
             initial_value: None,
             information: DataTypeInformation::String {
                 size: DEFAULT_STRING_LEN + 1,
+                encoding: StringEncoding::Utf8,
+            },
+        },
+        DataType {
+            name: "WSTRING".into(),
+            initial_value: None,
+            information: DataTypeInformation::String {
+                size: DEFAULT_STRING_LEN + 1,
+                encoding: StringEncoding::Utf16,
             },
         },
     ]
 }
 
 pub fn new_string_information(len: u32) -> DataTypeInformation {
-    DataTypeInformation::String { size: len + 1 }
+    DataTypeInformation::String {
+        size: len + 1,
+        encoding: StringEncoding::Utf8,
+    }
+}
+
+pub fn new_wide_string_information(len: u32) -> DataTypeInformation {
+    DataTypeInformation::String {
+        size: len + 1,
+        encoding: StringEncoding::Utf16,
+    }
 }
 
 fn get_rank(type_information: &DataTypeInformation) -> u32 {


### PR DESCRIPTION
WSTRINGs work like Strings, the data is stored in utf16-byte arrays
WSTRING literals are denoted using the double-ticks "

added mdbook entries for STRING and WSTRING
closes #171