### PR TITLE
Default CLI options

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -174,7 +174,7 @@ jobs:
       
       - name: Generate coverage report
         run:
-          grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
+          grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore "src/main.rs" --ignore-not-existing --ignore "/*" -o lcov.info
 
 
       - name: Upload to codecov.io

--- a/book/src/using_rusty.md
+++ b/book/src/using_rusty.md
@@ -1,13 +1,22 @@
 # Using RuSTy
 
 `rustyc` offers a comprehensive help via the -h (--help) option. `rustyc` takes 
-one output-format parameter and any number of input-files.
-
-The input files can also be written as [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)).
+one output-format parameter and any number of input-files. The input files can also be
+written as [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)).
 
 `rustyc [OPTIONS] <input-files>... <--ir|--shared|--pic|--static|--bc>`
 
-Examples:
+Note that you can only specify at most one output format. In the case that no output
+format switch has been specified, the compiler will select `--static` by default.
+
+Similarily, if you do not specify an output filename via the `-o` or `--output` options,
+the output filename will consist of the first input filename, but with an appropriate
+file extension depending on the output file format. A minimal invocation looks like this:
+
+`rustyc input.st` ... this will take in the file input.st and compile it into a static object
+that will be written to a file named input.o.
+
+More examples:
 
 - `rustyc --ir file1.st file2.st` will compile file1.st and file2.st.
 - `rustyc --ir src/*.st` will compile all st files in the src-folder.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,6 @@ pub enum FormatOption {
     Shared,
     Bitcode,
     IR,
-    None,
 }
 
 // => Set the default output format here:
@@ -85,19 +84,19 @@ impl CompileParameters {
     }
 
     // convert the scattered bools from structopt into an enum
-    pub fn output_format(&self) -> FormatOption {
+    pub fn output_format(&self) -> Option<FormatOption> {
         if self.output_bit_code {
-            FormatOption::Bitcode
+            Some(FormatOption::Bitcode)
         } else if self.output_ir {
-            FormatOption::IR
+            Some(FormatOption::IR)
         } else if self.output_pic_obj {
-            FormatOption::PIC
+            Some(FormatOption::PIC)
         } else if self.output_shared_obj {
-            FormatOption::Shared
+            Some(FormatOption::Shared)
         } else if self.output_obj_code {
-            FormatOption::Static
+            Some(FormatOption::Static)
         } else {
-            FormatOption::None
+            None
         }
     }
 
@@ -105,12 +104,7 @@ impl CompileParameters {
     pub fn output_format_or_default(&self) -> FormatOption {
         // structop makes sure only one or zero format flags are
         // selected. So if none are selected, the default is chosen
-        let output_format = self.output_format();
-        if output_format == FormatOption::None {
-            DEFAULT_FORMAT
-        } else {
-            output_format
-        }
+        self.output_format().unwrap_or_else(|| DEFAULT_FORMAT)
     }
 
     /// return the output filename with the correct ending
@@ -124,7 +118,6 @@ impl CompileParameters {
                 FormatOption::Shared => "so",
                 FormatOption::PIC => "so",
                 FormatOption::IR => "ir",
-                _ => panic!("don't know what ending to choose!"),
             };
 
             let output_name = self.input.first().unwrap();
@@ -201,7 +194,7 @@ mod cli_tests {
         let parameters =
             CompileParameters::parse(vec_of_strings!("input.st", "--ir", "-o", "myout.out"))
                 .unwrap();
-        assert_eq!(parameters.output.unwrap(), "myout.out".to_string());
+        assert_eq!(parameters.output_name().unwrap(), "myout.out".to_string());
 
         //long --output
         let parameters = CompileParameters::parse(vec_of_strings!(
@@ -211,7 +204,7 @@ mod cli_tests {
             "myout2.out"
         ))
         .unwrap();
-        assert_eq!(parameters.output.unwrap(), "myout2.out".to_string());
+        assert_eq!(parameters.output_name().unwrap(), "myout2.out".to_string());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ pub fn parse_parameters(args: Vec<String>) -> Result<CompileParameters, Paramete
 
 #[derive(StructOpt, Debug)]
 #[structopt(
-        group = ArgGroup::with_name("format").required(true),
+        group = ArgGroup::with_name("format") /* .required(true) */,
         about = "IEC61131-3 Structured Text compiler powered by Rust & LLVM "
     )]
 pub struct CompileParameters {
@@ -96,11 +96,6 @@ mod cli_tests {
     fn missing_parameters_results_in_error() {
         // no arguments
         expect_argument_error(vec![], ErrorKind::MissingRequiredArgument);
-        // only input file, missing format
-        expect_argument_error(
-            vec_of_strings!["input.st"],
-            ErrorKind::MissingRequiredArgument,
-        );
         // no input file
         expect_argument_error(vec_of_strings!["--ir"], ErrorKind::MissingRequiredArgument);
     }
@@ -143,6 +138,7 @@ mod cli_tests {
         let parameters =
             parse_parameters(vec_of_strings!("input.st", "--ir", "-o", "myout.out")).unwrap();
         assert_eq!(parameters.output, "myout.out".to_string());
+
         //long --output
         let parameters = parse_parameters(vec_of_strings!(
             "input.st",
@@ -190,6 +186,13 @@ mod cli_tests {
         assert_eq!(parameters.output_obj_code, false);
         assert_eq!(parameters.output_pic_obj, false);
         assert_eq!(parameters.output_shared_obj, true);
+
+        let parameters = parse_parameters(vec_of_strings!("input.st")).unwrap();
+        assert_eq!(parameters.output_ir, false);
+        assert_eq!(parameters.output_bit_code, false);
+        assert_eq!(parameters.output_obj_code, false);
+        assert_eq!(parameters.output_pic_obj, false);
+        assert_eq!(parameters.output_shared_obj, false);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,7 +104,7 @@ impl CompileParameters {
     pub fn output_format_or_default(&self) -> FormatOption {
         // structop makes sure only one or zero format flags are
         // selected. So if none are selected, the default is chosen
-        self.output_format().unwrap_or_else(|| DEFAULT_FORMAT)
+        self.output_format().unwrap_or(DEFAULT_FORMAT)
     }
 
     /// return the output filename with the correct ending

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ pub type ParameterError = structopt::clap::Error;
 
 #[derive(StructOpt, Debug)]
 #[structopt(
-    group = ArgGroup::with_name("format") /* .required(true) */,
+    group = ArgGroup::with_name("format"),
     about = "IEC61131-3 Structured Text compiler powered by Rust & LLVM "
 )]
 pub struct CompileParameters {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,9 @@ fn main_compile(parameters: CompileParameters) {
         .collect::<Vec<_>>();
 
     let sources = sources.as_slice();
-    let output_filename = parameters.output_name();
-
-    println!("output_filename: {}", output_filename);
+    let output_filename = parameters.output_name().unwrap_or_else(|| {
+        panic!("Bad output file path!");
+    });
 
     match parameters.output_format_or_default() {
         FormatOption::Static => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@
 //! [`IR`]: https://llvm.org/docs/LangRef.html
 use glob::glob;
 use rusty::{
-    cli::{parse_parameters, CompileParameters, ParameterError},
+    cli::{CompileParameters, FormatOption, ParameterError},
     compile_error::CompileError,
     compile_to_bitcode, compile_to_ir, compile_to_shared_object, compile_to_static_obj, SourceCode,
     SourceContainer,
@@ -29,7 +29,8 @@ use std::fs;
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
-    let compile_parameters: Result<CompileParameters, ParameterError> = parse_parameters(args);
+    let compile_parameters: Result<CompileParameters, ParameterError> =
+        CompileParameters::parse(args);
     match compile_parameters {
         Ok(cp) => main_compile(cp),
         Err(err) => err.exit(), // prints the nice message to std-out
@@ -78,16 +79,24 @@ fn main_compile(parameters: CompileParameters) {
         .collect::<Vec<_>>();
 
     let sources = sources.as_slice();
+    let output_filename = parameters.output_name();
 
-    if parameters.output_bit_code {
-        compile_to_bitcode(sources, parameters.output.as_str()).unwrap();
-    } else if parameters.output_ir {
-        generate_ir(sources, parameters.output.as_str()).unwrap();
-    } else if parameters.output_pic_obj || parameters.output_shared_obj {
-        compile_to_shared_object(sources, parameters.output.as_str(), parameters.target).unwrap();
-    } else {
-        // default is static
-        compile_to_static_obj(sources, parameters.output.as_str(), parameters.target).unwrap();
+    println!("output_filename: {}", output_filename);
+
+    match parameters.output_format_or_default() {
+        FormatOption::Static => {
+            compile_to_static_obj(sources, output_filename.as_str(), parameters.target).unwrap();
+        }
+        FormatOption::Shared | FormatOption::PIC => {
+            compile_to_shared_object(sources, output_filename.as_str(), parameters.target).unwrap();
+        }
+        FormatOption::Bitcode => {
+            compile_to_bitcode(sources, output_filename.as_str()).unwrap();
+        }
+        FormatOption::IR => {
+            generate_ir(sources, output_filename.as_str()).unwrap();
+        }
+        _ => panic!("output_format_or_default() should not return None!"),
     }
 }
 fn generate_ir(sources: &[&dyn SourceContainer], output: &str) -> Result<(), CompileError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,15 +83,11 @@ fn main_compile(parameters: CompileParameters) {
         compile_to_bitcode(sources, parameters.output.as_str()).unwrap();
     } else if parameters.output_ir {
         generate_ir(sources, parameters.output.as_str()).unwrap();
-    } else if parameters.output_pic_obj {
+    } else if parameters.output_pic_obj || parameters.output_shared_obj {
         compile_to_shared_object(sources, parameters.output.as_str(), parameters.target).unwrap();
-    } else if parameters.output_shared_obj {
-        compile_to_shared_object(sources, parameters.output.as_str(), parameters.target).unwrap()
-    } else if parameters.output_obj_code {
-        compile_to_static_obj(sources, parameters.output.as_str(), parameters.target).unwrap();
     } else {
-        //none is set, so we use default
-        panic!("no output format defined");
+        // default is static
+        compile_to_static_obj(sources, parameters.output.as_str(), parameters.target).unwrap();
     }
 }
 fn generate_ir(sources: &[&dyn SourceContainer], output: &str) -> Result<(), CompileError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,7 @@ fn main_compile(parameters: CompileParameters) {
         .collect::<Vec<_>>();
 
     let sources = sources.as_slice();
-    let output_filename = parameters.output_name().unwrap_or_else(|| {
-        panic!("Bad output file path!");
-    });
+    let output_filename = parameters.output_name().unwrap();
 
     match parameters.output_format_or_default() {
         FormatOption::Static => {
@@ -96,7 +94,6 @@ fn main_compile(parameters: CompileParameters) {
         FormatOption::IR => {
             generate_ir(sources, output_filename.as_str()).unwrap();
         }
-        _ => panic!("output_format_or_default() should not return None!"),
     }
 }
 fn generate_ir(sources: &[&dyn SourceContainer], output: &str) -> Result<(), CompileError> {


### PR DESCRIPTION
This will resolve #172 

Changes:
* No output format choice will fallback to default, which is "--static"
* Default can easily be changed by modifying a single constant
* Output filenames are automatically given the correct extension based on the file format
* Additional tests that cover the new behaviour