### PR TITLE
Allow action container to inherit its name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ impl Diagnostic {
         }
     }
 
-    pub fn missing_action_container(range : SourceRange) -> Diagnostic{
+    pub fn missing_action_container(range: SourceRange) -> Diagnostic {
         Diagnostic::SyntaxError {
             message: "Missing Actions Container Name".to_string(),
             range,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,13 @@ impl Diagnostic {
         }
     }
 
+    pub fn missing_action_container(range : SourceRange) -> Diagnostic{
+        Diagnostic::SyntaxError {
+            message: "Missing Actions Container Name".to_string(),
+            range,
+        }
+    }
+
     pub fn get_message(&self) -> &str {
         match self {
             Diagnostic::SyntaxError { message, .. } => message.as_str(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,7 +65,8 @@ pub fn parse(mut lexer: ParseSession) -> PResult<ParsedAst> {
                 }
             }
             KeywordActions => {
-                let mut actions = parse_actions(&mut lexer, linkage)?;
+                let last_pou = unit.units.last().map(|it| it.name.as_str()).unwrap_or("__unknown__");
+                let mut actions = parse_actions(&mut lexer, linkage, last_pou)?;
                 unit.implementations.append(&mut actions);
             }
             KeywordType => {
@@ -90,10 +91,15 @@ pub fn parse(mut lexer: ParseSession) -> PResult<ParsedAst> {
 fn parse_actions(
     mut lexer: &mut ParseSession,
     linkage: LinkageType,
+    default_container : &str,
 ) -> Result<Vec<Implementation>, Diagnostic> {
     lexer.advance(); //Consume ACTIONS
-    lexer.expect(Identifier)?;
-    let container = lexer.slice_and_advance();
+    let container = if lexer.token == Identifier {
+        lexer.slice_and_advance()
+    } else {
+        lexer.accept_diagnostic(Diagnostic::missing_action_container(lexer.location()));
+        default_container.into()
+    };
     let mut result = vec![];
 
     //Go through each action

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,7 +65,11 @@ pub fn parse(mut lexer: ParseSession) -> PResult<ParsedAst> {
                 }
             }
             KeywordActions => {
-                let last_pou = unit.units.last().map(|it| it.name.as_str()).unwrap_or("__unknown__");
+                let last_pou = unit
+                    .units
+                    .last()
+                    .map(|it| it.name.as_str())
+                    .unwrap_or("__unknown__");
                 let mut actions = parse_actions(&mut lexer, linkage, last_pou)?;
                 unit.implementations.append(&mut actions);
             }
@@ -91,7 +95,7 @@ pub fn parse(mut lexer: ParseSession) -> PResult<ParsedAst> {
 fn parse_actions(
     mut lexer: &mut ParseSession,
     linkage: LinkageType,
-    default_container : &str,
+    default_container: &str,
 ) -> Result<Vec<Implementation>, Diagnostic> {
     lexer.advance(); //Consume ACTIONS
     let container = if lexer.token == Identifier {

--- a/src/parser/tests/container_parser_tests.rs
+++ b/src/parser/tests/container_parser_tests.rs
@@ -59,20 +59,26 @@ fn actions_with_no_container_have_unkown_container() {
 
 #[test]
 fn actions_with_no_container_inherits_previous_pou() {
-    let lexer = lex("PROGRAM foo END_PROGRAM ACTIONS ACTION bar END_ACTION END_ACTIONS");
+    let lexer = lex(
+        "PROGRAM buz END_PROGRAM PROGRAM foo END_PROGRAM ACTIONS ACTION bar END_ACTION END_ACTIONS",
+    );
     let (result, diagnostic) = parse(lexer).unwrap();
     let prg = &result.implementations[0];
+    assert_eq!(prg.name, "buz");
+    assert_eq!(prg.type_name, "buz");
+
+    let prg = &result.implementations[1];
     assert_eq!(prg.name, "foo");
     assert_eq!(prg.type_name, "foo");
 
-    let prg = &result.implementations[1];
+    let prg = &result.implementations[2];
     assert_eq!(prg.name, "foo.bar");
     assert_eq!(prg.type_name, "foo");
 
     //Expect a diagnostic
     assert_eq!(
         diagnostic,
-        [Diagnostic::missing_action_container((32..38).into())]
+        [Diagnostic::missing_action_container((56..62).into())]
     );
 }
 

--- a/src/parser/tests/container_parser_tests.rs
+++ b/src/parser/tests/container_parser_tests.rs
@@ -1,4 +1,7 @@
-use crate::{Diagnostic, parser::{parse, tests::lex}};
+use crate::{
+    parser::{parse, tests::lex},
+    Diagnostic,
+};
 use pretty_assertions::*;
 
 #[test]
@@ -48,9 +51,10 @@ fn actions_with_no_container_have_unkown_container() {
     assert_eq!(prg.type_name, "__unknown__");
 
     //Expect a diagnostic
-    assert_eq!(diagnostic, [
-       Diagnostic::missing_action_container((8..14).into()) 
-    ]);
+    assert_eq!(
+        diagnostic,
+        [Diagnostic::missing_action_container((8..14).into())]
+    );
 }
 
 #[test]
@@ -66,10 +70,10 @@ fn actions_with_no_container_inherits_previous_pou() {
     assert_eq!(prg.type_name, "foo");
 
     //Expect a diagnostic
-    assert_eq!(diagnostic, [
-       Diagnostic::missing_action_container((32..38).into()) 
-    ]);
-
+    assert_eq!(
+        diagnostic,
+        [Diagnostic::missing_action_container((32..38).into())]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #206 

Uses a best-effort method to find the POU name (Last POU in the list)
If no POU is found, the name unknown is added as a container.
A diagnostic is produced if the name is missing.