### PR TITLE
ignore tests added in 55286718

### DIFF
--- a/tests/integration/external_files.rs
+++ b/tests/integration/external_files.rs
@@ -35,11 +35,13 @@ fn get_file(name : &str) -> String {
 
 }
 
+#[ignore = "ends in endless build in cargo watch"]
 #[test]
 fn compile_external_file() {
     compile_all("test_file.st", None);
 }
 
+#[ignore = "ends in endless build in cargo watch"]
 #[test]
 fn compile_external_file_with_encoding() {
     compile_all("encoding_utf_16.st", None);


### PR DESCRIPTION
two integration tests cause cargo watch to build
in an endless loop.