### PR TITLE
Ast annotation (annotated parse tree - part1)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -18,6 +18,8 @@ impl Dimension {
     }
 }
 
+pub type AstId = usize;
+
 #[derive(PartialEq)]
 pub struct Pou {
     pub name: String,
@@ -359,17 +361,20 @@ impl Debug for ConditionalBlock {
 pub enum Statement {
     EmptyStatement {
         location: SourceRange,
+        id: AstId,
     },
     // Literals
     LiteralInteger {
         value: i64,
         location: SourceRange,
+        id: AstId,
     },
     LiteralDate {
         year: i32,
         month: u32,
         day: u32,
         location: SourceRange,
+        id: AstId,
     },
     LiteralDateAndTime {
         year: i32,
@@ -380,6 +385,7 @@ pub enum Statement {
         sec: u32,
         milli: u32,
         location: SourceRange,
+        id: AstId,
     },
     LiteralTimeOfDay {
         hour: u32,
@@ -387,6 +393,7 @@ pub enum Statement {
         sec: u32,
         milli: u32,
         location: SourceRange,
+        id: AstId,
     },
     LiteralTime {
         day: f64,
@@ -398,79 +405,96 @@ pub enum Statement {
         nano: u32,
         negative: bool,
         location: SourceRange,
+        id: AstId,
     },
     LiteralReal {
         value: String,
         location: SourceRange,
+        id: AstId,
     },
     LiteralBool {
         value: bool,
         location: SourceRange,
+        id: AstId,
     },
     LiteralString {
         value: String,
         is_wide: bool,
         location: SourceRange,
+        id: AstId,
     },
     LiteralArray {
         elements: Option<Box<Statement>>, // expression-list
         location: SourceRange,
+        id: AstId,
     },
     MultipliedStatement {
         multiplier: u32,
         element: Box<Statement>,
         location: SourceRange,
+        id: AstId,
     },
     // Expressions
     QualifiedReference {
         elements: Vec<Statement>,
+        id: AstId,
     },
     Reference {
         name: String,
         location: SourceRange,
+        id: AstId,
     },
     ArrayAccess {
         reference: Box<Statement>,
         access: Box<Statement>,
+        id: AstId,
     },
     BinaryExpression {
         operator: Operator,
         left: Box<Statement>,
         right: Box<Statement>,
+        id: AstId,
     },
     UnaryExpression {
         operator: Operator,
         value: Box<Statement>,
         location: SourceRange,
+        id: AstId,
     },
     ExpressionList {
         expressions: Vec<Statement>,
+        id: AstId,
     },
     RangeStatement {
         start: Box<Statement>,
         end: Box<Statement>,
+        id: AstId,
     },
     // Assignment
     Assignment {
         left: Box<Statement>,
         right: Box<Statement>,
+        id: AstId,
     },
     // OutputAssignment
     OutputAssignment {
         left: Box<Statement>,
         right: Box<Statement>,
+        id: AstId,
     },
     //Call Statement
     CallStatement {
         operator: Box<Statement>,
         parameters: Box<Option<Statement>>,
         location: SourceRange,
+        id: AstId,
     },
     // Control Statements
     IfStatement {
         blocks: Vec<ConditionalBlock>,
         else_block: Vec<Statement>,
         location: SourceRange,
+        id: AstId,
     },
     ForLoopStatement {
         counter: Box<Statement>,
@@ -479,25 +503,30 @@ pub enum Statement {
         by_step: Option<Box<Statement>>,
         body: Vec<Statement>,
         location: SourceRange,
+        id: AstId,
     },
     WhileLoopStatement {
         condition: Box<Statement>,
         body: Vec<Statement>,
         location: SourceRange,
+        id: AstId,
     },
     RepeatLoopStatement {
         condition: Box<Statement>,
         body: Vec<Statement>,
         location: SourceRange,
+        id: AstId,
     },
     CaseStatement {
         selector: Box<Statement>,
         case_blocks: Vec<ConditionalBlock>,
         else_block: Vec<Statement>,
         location: SourceRange,
+        id: AstId,
     },
     CaseCondition {
         condition: Box<Statement>,
+        id: AstId,
     },
 }
 
@@ -610,21 +639,21 @@ impl Debug for Statement {
                 .field("operator", operator)
                 .field("value", value)
                 .finish(),
-            Statement::ExpressionList { expressions } => f
+            Statement::ExpressionList { expressions, .. } => f
                 .debug_struct("ExpressionList")
                 .field("expressions", expressions)
                 .finish(),
-            Statement::RangeStatement { start, end } => f
+            Statement::RangeStatement { start, end, .. } => f
                 .debug_struct("RangeStatement")
                 .field("start", start)
                 .field("end", end)
                 .finish(),
-            Statement::Assignment { left, right } => f
+            Statement::Assignment { left, right, .. } => f
                 .debug_struct("Assignment")
                 .field("left", left)
                 .field("right", right)
                 .finish(),
-            Statement::OutputAssignment { left, right } => f
+            Statement::OutputAssignment { left, right, .. } => f
                 .debug_struct("OutputAssignment")
                 .field("left", left)
                 .field("right", right)
@@ -701,7 +730,7 @@ impl Debug for Statement {
                 .field("multiplier", multiplier)
                 .field("element", element)
                 .finish(),
-            Statement::CaseCondition { condition } => f
+            Statement::CaseCondition { condition, .. } => f
                 .debug_struct("CaseCondition")
                 .field("condition", condition)
                 .finish(),
@@ -712,7 +741,7 @@ impl Debug for Statement {
 impl Statement {
     ///Returns the statement in a singleton list, or the contained statements if the statement is already a list
     pub fn get_as_list(&self) -> Vec<&Statement> {
-        if let Statement::ExpressionList { expressions } = self {
+        if let Statement::ExpressionList { expressions, .. } = self {
             expressions.iter().collect::<Vec<&Statement>>()
         } else {
             vec![self]
@@ -746,7 +775,7 @@ impl Statement {
                 SourceRange::new(left_loc.range.start..right_loc.range.end)
             }
             Statement::UnaryExpression { location, .. } => location.clone(),
-            Statement::ExpressionList { expressions } => {
+            Statement::ExpressionList { expressions, .. } => {
                 let first = expressions
                     .first()
                     .map_or_else(SourceRange::undefined, |it| it.get_location());
@@ -755,17 +784,17 @@ impl Statement {
                     .map_or_else(SourceRange::undefined, |it| it.get_location());
                 SourceRange::new(first.get_start()..last.get_end())
             }
-            Statement::RangeStatement { start, end } => {
+            Statement::RangeStatement { start, end, .. } => {
                 let start_loc = start.get_location();
                 let end_loc = end.get_location();
                 SourceRange::new(start_loc.range.start..end_loc.range.end)
             }
-            Statement::Assignment { left, right } => {
+            Statement::Assignment { left, right, .. } => {
                 let left_loc = left.get_location();
                 let right_loc = right.get_location();
                 SourceRange::new(left_loc.range.start..right_loc.range.end)
             }
-            Statement::OutputAssignment { left, right } => {
+            Statement::OutputAssignment { left, right, .. } => {
                 let left_loc = left.get_location();
                 let right_loc = right.get_location();
                 SourceRange::new(left_loc.range.start..right_loc.range.end)
@@ -776,13 +805,47 @@ impl Statement {
             Statement::WhileLoopStatement { location, .. } => location.clone(),
             Statement::RepeatLoopStatement { location, .. } => location.clone(),
             Statement::CaseStatement { location, .. } => location.clone(),
-            Statement::ArrayAccess { reference, access } => {
+            Statement::ArrayAccess {
+                reference, access, ..
+            } => {
                 let reference_loc = reference.get_location();
                 let access_loc = access.get_location();
                 SourceRange::new(reference_loc.range.start..access_loc.range.end)
             }
             Statement::MultipliedStatement { location, .. } => location.clone(),
-            Statement::CaseCondition { condition } => condition.get_location(),
+            Statement::CaseCondition { condition, .. } => condition.get_location(),
+        }
+    }
+
+    pub fn get_id(&self) -> AstId {
+        match self {
+            Statement::EmptyStatement { id, .. } => *id,
+            Statement::LiteralInteger { id, .. } => *id,
+            Statement::LiteralDate { id, .. } => *id,
+            Statement::LiteralDateAndTime { id, .. } => *id,
+            Statement::LiteralTimeOfDay { id, .. } => *id,
+            Statement::LiteralTime { id, .. } => *id,
+            Statement::LiteralReal { id, .. } => *id,
+            Statement::LiteralBool { id, .. } => *id,
+            Statement::LiteralString { id, .. } => *id,
+            Statement::LiteralArray { id, .. } => *id,
+            Statement::MultipliedStatement { id, .. } => *id,
+            Statement::QualifiedReference { id, .. } => *id,
+            Statement::Reference { id, .. } => *id,
+            Statement::ArrayAccess { id, .. } => *id,
+            Statement::BinaryExpression { id, .. } => *id,
+            Statement::UnaryExpression { id, .. } => *id,
+            Statement::ExpressionList { id, .. } => *id,
+            Statement::RangeStatement { id, .. } => *id,
+            Statement::Assignment { id, .. } => *id,
+            Statement::OutputAssignment { id, .. } => *id,
+            Statement::CallStatement { id, .. } => *id,
+            Statement::IfStatement { id, .. } => *id,
+            Statement::ForLoopStatement { id, .. } => *id,
+            Statement::WhileLoopStatement { id, .. } => *id,
+            Statement::RepeatLoopStatement { id, .. } => *id,
+            Statement::CaseStatement { id, .. } => *id,
+            Statement::CaseCondition { id, .. } => *id,
         }
     }
 }
@@ -824,7 +887,7 @@ impl Display for Operator {
 /// It can also handle nested structures like 2(3(4,5))
 pub fn flatten_expression_list(condition: &Statement) -> Vec<&Statement> {
     match condition {
-        Statement::ExpressionList { expressions } => expressions
+        Statement::ExpressionList { expressions, .. } => expressions
             .iter()
             .by_ref()
             .flat_map(|statement| flatten_expression_list(statement))
@@ -858,7 +921,7 @@ pub fn get_array_dimensions(bounds: &Statement) -> result::Result<Vec<Dimension>
 /// constructs a Dimension for the given RangeStatement
 /// throws an error if the given statement is no RangeStatement
 fn get_single_array_dimension(bounds: &Statement) -> result::Result<Dimension, CompileError> {
-    if let Statement::RangeStatement { start, end } = bounds {
+    if let Statement::RangeStatement { start, end, .. } = bounds {
         let start_offset = evaluate_constant_int(start).unwrap_or(0);
         let end_offset = evaluate_constant_int(end).unwrap_or(0);
         Ok(Dimension {

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -244,6 +244,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
             let left = Statement::Reference {
                 name: variable.get_name().into(),
                 location: variable.source_location.clone(),
+                id: 0, //TODO
             };
             let right = variable.initial_value.as_ref().unwrap();
             statement_generator.generate_assignment_statement(&left, right)?;
@@ -266,6 +267,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
                 let reference = Statement::Reference {
                     name: function_context.linking_context.get_call_name().into(),
                     location: location.unwrap_or_else(SourceRange::undefined),
+                    id: 0, //TODO
                 };
                 let mut exp_gen = ExpressionCodeGenerator::new(
                     &self.llvm,

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -83,7 +83,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             Statement::EmptyStatement { .. } => {
                 //nothing to generate
             }
-            Statement::Assignment { left, right } => {
+            Statement::Assignment { left, right, .. } => {
                 self.generate_assignment_statement(left, right)?;
             }
             Statement::ForLoopStatement {
@@ -257,6 +257,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
                 expression_generator.generate_literal(&Statement::LiteralInteger {
                     value: 1,
                     location: end.get_location(),
+                    id: 0, //TODO
                 })
             },
             |step| expression_generator.generate_expression(&step),
@@ -332,7 +333,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             //flatten the expression list into a vector of expressions
             let expressions = flatten_expression_list(&*conditional_block.condition);
             for s in expressions {
-                if let Statement::RangeStatement { start, end } = s {
+                if let Statement::RangeStatement { start, end, .. } = s {
                     //if this is a range statement, we generate an if (x >= start && x <= end) then the else-section
                     builder.position_at_end(current_else_block);
                     // since the if's generate additional blocks, we use the last one as the else-section
@@ -610,10 +611,13 @@ fn create_call_to_check_function_ast(
         operator: Box::new(Statement::Reference {
             name: check_function_name,
             location: location.clone(),
+            id: 0, //TODO
         }),
         parameters: Box::new(Some(Statement::ExpressionList {
             expressions: vec![parameter, sub_range.start, sub_range.end],
+            id: 0, //TODO
         })),
         location: location.clone(),
+        id: 0, //TODO
     }
 }

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -744,11 +744,14 @@ fn pre_processing_generates_inline_arrays() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "INT".to_string(),
@@ -795,11 +798,14 @@ fn pre_processing_generates_inline_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "INT".to_string(),
@@ -818,11 +824,14 @@ fn pre_processing_generates_inline_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "__foo_inline_array_".to_string(),
@@ -893,11 +902,14 @@ fn pre_processing_nested_array_in_struct() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 4,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "INT".to_string(),
@@ -935,11 +947,14 @@ fn pre_processing_generates_inline_array_of_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "INT".to_string(),
@@ -958,11 +973,14 @@ fn pre_processing_generates_inline_array_of_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "__foo_inline_array__".to_string(),
@@ -981,11 +999,14 @@ fn pre_processing_generates_inline_array_of_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "__foo_inline_array_".to_string(),
@@ -1023,9 +1044,11 @@ fn sub_range_boundaries_are_registered_at_the_index() {
         sub_range: Statement::LiteralInteger {
             value: 7,
             location: SourceRange::undefined(),
+            id: 0,
         }..Statement::LiteralInteger {
             value: 1000,
             location: SourceRange::undefined(),
+            id: 0,
         },
     };
 

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -246,6 +246,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                     Some(ast::Statement::LiteralInteger {
                         value: i as i64,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
                     SourceRange::undefined(),
                 )
@@ -257,7 +258,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
             referenced_type,
             bounds,
         } => {
-            let information = if let Some(Statement::RangeStatement { start, end }) = bounds {
+            let information = if let Some(Statement::RangeStatement { start, end, .. }) = bounds {
                 DataTypeInformation::SubRange {
                     name: name.as_ref().unwrap().into(),
                     referenced_type: referenced_type.into(),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -5,6 +5,7 @@ use logos::Lexer;
 use logos::Logos;
 pub use tokens::Token;
 
+use crate::ast::AstId;
 use crate::ast::SourceRange;
 use crate::Diagnostic;
 
@@ -22,6 +23,7 @@ pub struct ParseSession<'a> {
     /// the range of the `last_token`
     pub last_range: Range<usize>,
     pub parse_progress: usize,
+    current_id: AstId,
 }
 
 impl<'a> ParseSession<'a> {
@@ -34,9 +36,15 @@ impl<'a> ParseSession<'a> {
             last_token: Token::End,
             last_range: 0..0,
             parse_progress: 0,
+            current_id: 0,
         };
         lexer.advance();
         lexer
+    }
+
+    pub fn next_id(&mut self) -> AstId {
+        self.current_id += 1;
+        self.current_id
     }
 
     pub fn expect(&self, token: Token) -> Result<(), Diagnostic> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -550,6 +550,7 @@ fn parse_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnostic> {
     if lexer.last_token == KeywordColon {
         Ok(Statement::CaseCondition {
             condition: Box::new(result),
+            id: lexer.next_id(),
         })
     } else {
         Ok(result)
@@ -566,7 +567,10 @@ pub fn parse_statement_in_region<F: FnOnce(&mut ParseSession) -> PResult<Stateme
         let end = lexer.range().end;
         let location = SourceRange::new(start..end);
         //drop the originally parsed statement and replace with an empty-statement
-        Statement::EmptyStatement { location }
+        Statement::EmptyStatement {
+            id: lexer.next_id(),
+            location,
+        }
     })
 }
 

--- a/src/parser/control_parser.rs
+++ b/src/parser/control_parser.rs
@@ -50,6 +50,7 @@ fn parse_if_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnostic>
         blocks: conditional_blocks,
         else_block,
         location: SourceRange::new(start..end),
+        id: lexer.next_id(),
     })
 }
 
@@ -84,6 +85,7 @@ fn parse_for_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnostic
         by_step: step,
         body: body?,
         location: SourceRange::new(start..lexer.last_range.end),
+        id: lexer.next_id(),
     })
 }
 
@@ -98,6 +100,7 @@ fn parse_while_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnost
             lexer.accept_diagnostic(diagnostic);
             Statement::EmptyStatement {
                 location: (start_condition..lexer.range().end).into(),
+                id: lexer.next_id(),
             }
         }
     };
@@ -108,6 +111,7 @@ fn parse_while_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnost
         condition: Box::new(condition),
         body,
         location: SourceRange::new(start..lexer.last_range.end),
+        id: lexer.next_id(),
     })
 }
 
@@ -123,6 +127,7 @@ fn parse_repeat_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnos
     } else {
         Statement::EmptyStatement {
             location: lexer.location(),
+            id: lexer.next_id(),
         }
     };
 
@@ -130,6 +135,7 @@ fn parse_repeat_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnos
         condition: Box::new(condition),
         body,
         location: SourceRange::new(start..lexer.range().end),
+        id: lexer.next_id(),
     })
 }
 
@@ -149,7 +155,7 @@ fn parse_case_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnosti
         let mut current_condition = None;
         let mut current_body = vec![];
         for statement in body {
-            if let Statement::CaseCondition { condition } = statement {
+            if let Statement::CaseCondition { condition, .. } = statement {
                 if let Some(condition) = current_condition {
                     let block = ConditionalBlock {
                         condition,
@@ -168,6 +174,7 @@ fn parse_case_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnosti
                     ));
                     current_condition = Some(Box::new(Statement::EmptyStatement {
                         location: lexer.location(),
+                        id: lexer.next_id(),
                     }));
                 }
                 current_body.push(statement);
@@ -194,5 +201,6 @@ fn parse_case_statement(lexer: &mut ParseSession) -> Result<Statement, Diagnosti
         case_blocks,
         else_block,
         location: SourceRange::new(start..end),
+        id: lexer.next_id(),
     })
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -22,6 +22,7 @@ pub fn ref_to(name: &str) -> Statement {
     Statement::Reference {
         location: SourceRange::undefined(),
         name: name.to_string(),
+        id: 0,
     }
 }
 
@@ -29,5 +30,6 @@ pub fn ref_to(name: &str) -> Statement {
 pub fn empty_stmt() -> Statement {
     Statement::EmptyStatement {
         location: SourceRange::undefined(),
+        id: 0,
     }
 }

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -28,17 +28,22 @@ fn qualified_reference_statement_parsed() {
 
     if let Statement::QualifiedReference { elements, .. } = statement {
         assert_eq!(
-            elements,
-            &[
-                Statement::Reference {
-                    name: "a".to_string(),
-                    location: (12..13).into()
-                },
-                Statement::Reference {
-                    name: "x".to_string(),
-                    location: (14..15).into()
-                },
-            ]
+            format!("{:?}", elements),
+            format!(
+                "{:?}",
+                &[
+                    Statement::Reference {
+                        name: "a".to_string(),
+                        location: (12..13).into(),
+                        id: 0
+                    },
+                    Statement::Reference {
+                        name: "x".to_string(),
+                        location: (14..15).into(),
+                        id: 0
+                    },
+                ]
+            )
         );
     } else {
         panic!("Expected Reference but found {:?}", statement);
@@ -53,7 +58,7 @@ fn literal_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(7 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -68,7 +73,7 @@ fn literal_binary_with_underscore_number_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(45 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -83,7 +88,7 @@ fn literal_hex_number_with_underscores_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(3735928559 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -98,7 +103,7 @@ fn literal_hex_number_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(3735928559 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -113,7 +118,7 @@ fn literal_oct_number_with_underscores_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(63 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -128,7 +133,7 @@ fn literal_dec_number_with_underscores_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(43000 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -143,7 +148,7 @@ fn literal_oct_number_with_underscore_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(63 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -162,6 +167,7 @@ fn additon_of_two_variables_parsed() {
         operator,
         left,  //Box<Reference> {name : left}),
         right, //Box<Reference> {name : right}),
+        ..
     } = statement
     {
         if let Statement::Reference { name, .. } = &**left {
@@ -188,6 +194,7 @@ fn additon_of_three_variables_parsed() {
         operator,
         left,  //Box<Reference> {name : left}),
         right, //Box<Reference> {name : right}),
+        ..
     } = statement
     {
         assert_eq!(operator, &Operator::Plus);
@@ -198,6 +205,7 @@ fn additon_of_three_variables_parsed() {
             operator,
             left,
             right,
+            ..
         } = &**right
         {
             if let Statement::Reference { name, .. } = &**left {
@@ -227,6 +235,7 @@ fn parenthesis_expressions_should_not_change_the_ast() {
         operator,
         left,
         right,
+        ..
     } = statement
     {
         if let Statement::Reference { name, .. } = &**left {

--- a/src/parser/tests/misc_parser_tests.rs
+++ b/src/parser/tests/misc_parser_tests.rs
@@ -1,3 +1,5 @@
+use core::panic;
+
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::{
     ast::*,
@@ -17,4 +19,384 @@ fn programs_can_be_external() {
     let parse_result = parse(lexer).unwrap().0;
     let implementation = &parse_result.implementations[0];
     assert_eq!(LinkageType::External, implementation.linkage);
+}
+
+#[test]
+fn ids_are_assigned_to_parsed_literals() {
+    let lexer = lex("
+    PROGRAM PRG
+        ;
+        (* literals *)
+        1;
+        D#2021-10-01;
+        DT#2021-10-01-20:15:00;
+        TOD#23:59:59.999;
+        TIME#2d4h6m8s10ms;
+        3.1415;
+        TRUE;
+        'abc';
+        [1,2,3];
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    assert_eq!(implementation.statements[0].get_id(), 1);
+    assert_eq!(implementation.statements[1].get_id(), 2);
+    assert_eq!(implementation.statements[2].get_id(), 3);
+    assert_eq!(implementation.statements[3].get_id(), 4);
+    assert_eq!(implementation.statements[4].get_id(), 5);
+    assert_eq!(implementation.statements[5].get_id(), 6);
+    assert_eq!(implementation.statements[6].get_id(), 7);
+    assert_eq!(implementation.statements[7].get_id(), 8);
+    assert_eq!(implementation.statements[8].get_id(), 9);
+}
+
+#[test]
+fn ids_are_assigned_to_parsed_assignments() {
+    let lexer = lex("
+    PROGRAM PRG
+        a := b;
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    if let Statement::Assignment { id, left, right } = &implementation.statements[0] {
+        assert_eq!(left.get_id(), 1);
+        assert_eq!(right.get_id(), 2);
+        assert_eq!(*id, 3);
+    } else {
+        panic!("unexpected statement");
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_callstatements() {
+    let lexer = lex("
+    PROGRAM PRG
+        foo();
+        foo(1,2,3);
+        foo(a := 1, b => c, d);
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    if let Statement::CallStatement { id, operator, .. } = &implementation.statements[0] {
+        assert_eq!(operator.get_id(), 1);
+        assert_eq!(*id, 2);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::CallStatement {
+        id,
+        operator,
+        parameters,
+        ..
+    } = &implementation.statements[1]
+    {
+        assert_eq!(operator.get_id(), 3);
+        if let Some(Statement::ExpressionList { expressions, id }) = &**parameters {
+            assert_eq!(expressions[0].get_id(), 4);
+            assert_eq!(expressions[1].get_id(), 5);
+            assert_eq!(expressions[2].get_id(), 6);
+            assert_eq!(*id, 7);
+        }
+        assert_eq!(*id, 8);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::CallStatement {
+        id,
+        operator,
+        parameters,
+        ..
+    } = &implementation.statements[2]
+    {
+        assert_eq!(operator.get_id(), 9);
+        if let Some(Statement::ExpressionList { expressions, id }) = &**parameters {
+            if let Statement::Assignment {
+                left, right, id, ..
+            } = &expressions[0]
+            {
+                assert_eq!(left.get_id(), 10);
+                assert_eq!(right.get_id(), 11);
+                assert_eq!(*id, 12);
+            } else {
+                panic!("unexpected statement");
+            }
+            if let Statement::OutputAssignment {
+                left, right, id, ..
+            } = &expressions[1]
+            {
+                assert_eq!(left.get_id(), 13);
+                assert_eq!(right.get_id(), 14);
+                assert_eq!(*id, 15);
+            } else {
+                panic!("unexpected statement");
+            }
+            assert_eq!(expressions[2].get_id(), 16);
+            assert_eq!(*id, 17);
+        }
+        assert_eq!(*id, 18);
+    } else {
+        panic!("unexpected statement");
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_expressions() {
+    let lexer = lex("
+    PROGRAM PRG
+        a * b;
+        a.b;
+        a;
+        a[2];
+        -b;
+        a,b;
+        1..2;
+        5(a);
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    if let Statement::BinaryExpression {
+        id, left, right, ..
+    } = &implementation.statements[0]
+    {
+        assert_eq!(left.get_id(), 1);
+        assert_eq!(right.get_id(), 2);
+        assert_eq!(*id, 3);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::QualifiedReference { id, elements, .. } = &implementation.statements[1] {
+        assert_eq!(elements[0].get_id(), 4);
+        assert_eq!(elements[1].get_id(), 5);
+        assert_eq!(*id, 6);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::Reference { id, .. } = &implementation.statements[2] {
+        assert_eq!(*id, 7);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::ArrayAccess {
+        id,
+        reference,
+        access,
+        ..
+    } = &implementation.statements[3]
+    {
+        assert_eq!(reference.get_id(), 8);
+        assert_eq!(access.get_id(), 9);
+        assert_eq!(*id, 10);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::UnaryExpression { id, value, .. } = &implementation.statements[4] {
+        assert_eq!(value.get_id(), 11);
+        assert_eq!(*id, 12);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::ExpressionList {
+        id, expressions, ..
+    } = &implementation.statements[5]
+    {
+        assert_eq!(expressions[0].get_id(), 13);
+        assert_eq!(expressions[1].get_id(), 14);
+        assert_eq!(*id, 15);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::RangeStatement { id, start, end, .. } = &implementation.statements[6] {
+        assert_eq!(start.get_id(), 16);
+        assert_eq!(end.get_id(), 17);
+        assert_eq!(*id, 18);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::MultipliedStatement { id, element, .. } = &implementation.statements[7] {
+        assert_eq!(element.get_id(), 19);
+        assert_eq!(*id, 20);
+    } else {
+        panic!("unexpected statement");
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_if_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+        IF TRUE THEN
+            ;
+        ELSE    
+            ;
+        END_IF
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::IfStatement {
+            blocks, else_block, ..
+        } => {
+            assert_eq!(blocks[0].condition.get_id(), 1);
+            assert_eq!(blocks[0].body[0].get_id(), 2);
+            assert_eq!(else_block[0].get_id(), 3);
+            assert_eq!(implementation.statements[0].get_id(), 4);
+        }
+        _ => panic!("invalid statement"),
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_for_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+        FOR x := 1 TO 7 BY 2 DO
+            ;
+            ;
+            ;
+        END_FOR;
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::ForLoopStatement {
+            counter,
+            start,
+            end,
+            by_step,
+            id,
+            body,
+            ..
+        } => {
+            assert_eq!(counter.get_id(), 1);
+            assert_eq!(start.get_id(), 2);
+            assert_eq!(end.get_id(), 3);
+            assert_eq!(by_step.as_ref().unwrap().get_id(), 4);
+            assert_eq!(body[0].get_id(), 5);
+            assert_eq!(body[1].get_id(), 6);
+            assert_eq!(body[2].get_id(), 7);
+            assert_eq!(*id, 8);
+        }
+        _ => panic!("invalid statement"),
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_while_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+       WHILE TRUE DO
+            ;;
+        END_WHILE
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::WhileLoopStatement {
+            condition, body, ..
+        } => {
+            assert_eq!(condition.get_id(), 1);
+            assert_eq!(body[0].get_id(), 2);
+            assert_eq!(body[1].get_id(), 3);
+            assert_eq!(implementation.statements[0].get_id(), 4);
+        }
+        _ => panic!("invalid statement"),
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_repeat_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+       REPEAT
+            ;;
+       UNTIL TRUE END_REPEAT
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::RepeatLoopStatement {
+            condition, body, ..
+        } => {
+            assert_eq!(body[0].get_id(), 1);
+            assert_eq!(body[1].get_id(), 2);
+            assert_eq!(condition.get_id(), 3);
+            assert_eq!(implementation.statements[0].get_id(), 4);
+        }
+        _ => panic!("invalid statement"),
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_case_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+    CASE PumpState OF
+    0:
+        ;
+    1,2:
+        ;
+    ELSE
+        ;
+    END_CASE;
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).unwrap().0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::CaseStatement {
+            case_blocks,
+            else_block,
+            selector,
+            ..
+        } => {
+            //1st case block
+            assert_eq!(selector.get_id(), 1);
+            assert_eq!(case_blocks[0].condition.get_id(), 2);
+            assert_eq!(case_blocks[0].body[0].get_id(), 4);
+
+            //2nd case block
+            if let Statement::ExpressionList {
+                expressions, id, ..
+            } = case_blocks[1].condition.as_ref()
+            {
+                assert_eq!(expressions[0].get_id(), 5);
+                assert_eq!(expressions[1].get_id(), 6);
+                assert_eq!(*id, 7);
+            } else {
+                panic!("expected expression list")
+            }
+            assert_eq!(case_blocks[1].body[0].get_id(), 9);
+
+            //else block
+            assert_eq!(else_block[0].get_id(), 10);
+        }
+
+        _ => panic!("invalid statement"),
+    }
 }

--- a/src/parser/tests/misc_parser_tests.rs
+++ b/src/parser/tests/misc_parser_tests.rs
@@ -1,9 +1,13 @@
 use core::panic;
+use std::ops::Range;
 
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::{
     ast::*,
-    parser::{parse, tests::lex},
+    parser::{
+        parse,
+        tests::{empty_stmt, lex},
+    },
 };
 use pretty_assertions::*;
 
@@ -399,4 +403,571 @@ fn ids_are_assigned_to_case_statements() {
 
         _ => panic!("invalid statement"),
     }
+}
+
+#[test]
+fn id_implementation_for_all_statements() {
+    assert_eq!(
+        Statement::ArrayAccess {
+            access: Box::new(empty_stmt()),
+            reference: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::Assignment {
+            left: Box::new(empty_stmt()),
+            right: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::BinaryExpression {
+            left: Box::new(empty_stmt()),
+            right: Box::new(empty_stmt()),
+            operator: Operator::And,
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::BinaryExpression {
+            left: Box::new(empty_stmt()),
+            right: Box::new(empty_stmt()),
+            operator: Operator::And,
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::CallStatement {
+            operator: Box::new(empty_stmt()),
+            parameters: Box::new(None),
+            id: 7,
+            location: (1..5).into()
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::CaseCondition {
+            condition: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::CaseStatement {
+            selector: Box::new(empty_stmt()),
+            case_blocks: vec![],
+            else_block: vec![],
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::EmptyStatement {
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::ExpressionList {
+            expressions: vec![],
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::ForLoopStatement {
+            body: vec![],
+            by_step: None,
+            counter: Box::new(empty_stmt()),
+            end: Box::new(empty_stmt()),
+            start: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::IfStatement {
+            blocks: vec![],
+            else_block: vec![],
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralArray {
+            elements: None,
+            location: (1..5).into(),
+            id: 7,
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralBool {
+            value: true,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralInteger {
+            value: 7,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralDate {
+            day: 0,
+            month: 0,
+            year: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralDateAndTime {
+            day: 0,
+            month: 0,
+            year: 0,
+            hour: 0,
+            milli: 0,
+            min: 0,
+            sec: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralReal {
+            value: "2.3".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralString {
+            is_wide: false,
+            value: "2.3".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralTime {
+            day: 0.0,
+            hour: 0.0,
+            milli: 0.0,
+            min: 0.0,
+            sec: 0.0,
+            micro: 0.0,
+            nano: 0,
+            negative: false,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralTimeOfDay {
+            hour: 0,
+            min: 0,
+            sec: 0,
+            milli: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::MultipliedStatement {
+            element: Box::new(empty_stmt()),
+            multiplier: 9,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::OutputAssignment {
+            left: Box::new(empty_stmt()),
+            right: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::QualifiedReference {
+            elements: vec![],
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::RangeStatement {
+            start: Box::new(empty_stmt()),
+            end: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::Reference {
+            name: "ab".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::RepeatLoopStatement {
+            body: vec![],
+            condition: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::UnaryExpression {
+            operator: Operator::Minus,
+            value: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::WhileLoopStatement {
+            body: vec![],
+            condition: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+}
+
+fn at(location: Range<usize>) -> Statement {
+    Statement::EmptyStatement {
+        id: 7,
+        location: location.into(),
+    }
+}
+
+#[test]
+fn location_implementation_for_all_statements() {
+    assert_eq!(
+        Statement::ArrayAccess {
+            reference: Box::new(at(0..1)),
+            access: Box::new(at(2..4)),
+            id: 7
+        }
+        .get_location(),
+        (0..4).into()
+    );
+    assert_eq!(
+        Statement::Assignment {
+            left: Box::new(at(0..2)),
+            right: Box::new(at(3..8)),
+            id: 7
+        }
+        .get_location(),
+        (0..8).into()
+    );
+    assert_eq!(
+        Statement::BinaryExpression {
+            left: Box::new(at(0..2)),
+            right: Box::new(at(3..8)),
+            operator: Operator::And,
+            id: 7
+        }
+        .get_location(),
+        (0..8).into()
+    );
+    assert_eq!(
+        Statement::CallStatement {
+            operator: Box::new(empty_stmt()),
+            parameters: Box::new(None),
+            id: 7,
+            location: (1..5).into()
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::CaseCondition {
+            condition: Box::new(at(2..4)),
+            id: 7
+        }
+        .get_location(),
+        (2..4).into()
+    );
+    assert_eq!(
+        Statement::CaseStatement {
+            selector: Box::new(empty_stmt()),
+            case_blocks: vec![],
+            else_block: vec![],
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::EmptyStatement {
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::ExpressionList {
+            expressions: vec![at(0..3), at(4..8)],
+            id: 7
+        }
+        .get_location(),
+        (0..8).into()
+    );
+    assert_eq!(
+        Statement::ForLoopStatement {
+            body: vec![],
+            by_step: None,
+            counter: Box::new(empty_stmt()),
+            end: Box::new(empty_stmt()),
+            start: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::IfStatement {
+            blocks: vec![],
+            else_block: vec![],
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralArray {
+            elements: None,
+            location: (1..5).into(),
+            id: 7,
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralBool {
+            value: true,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralInteger {
+            value: 7,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralDate {
+            day: 0,
+            month: 0,
+            year: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralDateAndTime {
+            day: 0,
+            month: 0,
+            year: 0,
+            hour: 0,
+            milli: 0,
+            min: 0,
+            sec: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralReal {
+            value: "2.3".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralString {
+            is_wide: false,
+            value: "2.3".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralTime {
+            day: 0.0,
+            hour: 0.0,
+            milli: 0.0,
+            min: 0.0,
+            sec: 0.0,
+            micro: 0.0,
+            nano: 0,
+            negative: false,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralTimeOfDay {
+            hour: 0,
+            min: 0,
+            sec: 0,
+            milli: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::MultipliedStatement {
+            element: Box::new(empty_stmt()),
+            multiplier: 9,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::OutputAssignment {
+            left: Box::new(at(0..3)),
+            right: Box::new(at(4..9)),
+            id: 7
+        }
+        .get_location(),
+        (0..9).into()
+    );
+    assert_eq!(
+        Statement::QualifiedReference {
+            elements: vec![at(0..3), at(4..5)],
+            id: 7
+        }
+        .get_location(),
+        (0..5).into()
+    );
+    assert_eq!(
+        Statement::RangeStatement {
+            start: Box::new(at(0..3)),
+            end: Box::new(at(6..9)),
+            id: 7
+        }
+        .get_location(),
+        (0..9).into()
+    );
+    assert_eq!(
+        Statement::Reference {
+            name: "ab".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::RepeatLoopStatement {
+            body: vec![],
+            condition: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::UnaryExpression {
+            operator: Operator::Minus,
+            value: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::WhileLoopStatement {
+            body: vec![],
+            condition: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
 }

--- a/src/parser/tests/parse_errors/parse_error_containers_tests.rs
+++ b/src/parser/tests/parse_errors/parse_error_containers_tests.rs
@@ -42,7 +42,8 @@ fn missing_pou_name() {
             "{:#?}",
             Statement::Reference {
                 name: "a".into(),
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             }
         )
     );
@@ -81,7 +82,8 @@ fn missing_pou_name_2() {
             "{:#?}",
             Statement::Reference {
                 name: "x".into(),
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             }
         )
     );
@@ -114,7 +116,8 @@ fn illegal_end_pou_keyword() {
             "{:#?}",
             vec![Statement::Reference {
                 name: "b".into(),
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             }]
         )
     );
@@ -208,7 +211,8 @@ fn program_with_illegal_return_variable_declaration() {
             "{:#?}",
             vec![Statement::Reference {
                 name: "a".into(),
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             }]
         )
     );

--- a/src/parser/tests/parse_errors/parse_error_statements_tests.rs
+++ b/src/parser/tests/parse_errors/parse_error_statements_tests.rs
@@ -13,7 +13,7 @@ use pretty_assertions::*;
 /*
  * These tests deal with parsing-behavior in the expressions: ()  expressions: ()  presence of errors.
  * following scenarios will be tested:
- *  - missing semicolons at different locations
+ *  - missing semico id: ()  id: () lons at different locations
  *  - incomplete statements
  *  - incomplete statement-blocks (brackets)
  */
@@ -84,8 +84,10 @@ fn missing_comma_in_call_parameters() {
                 location: SourceRange::undefined(),
                 operator: Box::new(ref_to("buz")),
                 parameters: Box::new(Some(Statement::ExpressionList {
-                    expressions: vec![ref_to("a"), ref_to("b"),]
-                }))
+                    expressions: vec![ref_to("a"), ref_to("b"),],
+                    id: 0
+                })),
+                id: 0
             }]
         )
     );
@@ -131,8 +133,10 @@ fn illegal_semicolon_in_call_parameters() {
                     location: SourceRange::undefined(),
                     operator: Box::new(ref_to("buz")),
                     parameters: Box::new(Some(Statement::ExpressionList {
-                        expressions: vec![ref_to("a"), ref_to("b")]
-                    }))
+                        expressions: vec![ref_to("a"), ref_to("b")],
+                        id: 0
+                    })),
+                    id: 0
                 },
                 ref_to("c")
             ]
@@ -389,31 +393,37 @@ fn test_nested_if_with_missing_end_if() {
                 blocks: vec![ConditionalBlock {
                     condition: Box::new(Statement::LiteralBool {
                         value: false,
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     }),
                     body: vec![
                         Statement::IfStatement {
                             blocks: vec![ConditionalBlock {
                                 condition: Box::new(Statement::LiteralBool {
                                     value: true,
-                                    location: SourceRange::undefined()
+                                    location: SourceRange::undefined(),
+                                    id: 0
                                 }),
                                 body: vec![Statement::Assignment {
                                     left: Box::new(ref_to("x")),
-                                    right: Box::new(ref_to("y"))
+                                    right: Box::new(ref_to("y")),
+                                    id: 0
                                 }],
                             }],
                             else_block: vec![],
                             location: SourceRange::undefined(),
+                            id: 0,
                         },
                         Statement::Assignment {
                             left: Box::new(ref_to("y")),
-                            right: Box::new(ref_to("x"))
+                            right: Box::new(ref_to("x")),
+                            id: 0
                         }
                     ]
                 },],
                 else_block: vec![],
                 location: SourceRange::undefined(),
+                id: 0,
             },]
         )
     );
@@ -476,11 +486,13 @@ fn test_nested_for_with_missing_end_for() {
                 counter: Box::new(ref_to("x")),
                 start: Box::new(Statement::LiteralInteger {
                     value: 1,
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 2,
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 }),
                 by_step: None,
                 body: vec![
@@ -488,26 +500,32 @@ fn test_nested_for_with_missing_end_for() {
                         counter: Box::new(ref_to("x")),
                         start: Box::new(Statement::LiteralInteger {
                             value: 1,
-                            location: SourceRange::undefined()
+                            location: SourceRange::undefined(),
+                            id: 0
                         }),
                         end: Box::new(Statement::LiteralInteger {
                             value: 2,
-                            location: SourceRange::undefined()
+                            location: SourceRange::undefined(),
+                            id: 0
                         }),
 
                         by_step: None,
                         body: vec![Statement::Assignment {
                             left: Box::new(ref_to("y")),
-                            right: Box::new(ref_to("x"))
+                            right: Box::new(ref_to("x")),
+                            id: 0
                         },],
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("x")),
-                        right: Box::new(ref_to("y"))
+                        right: Box::new(ref_to("y")),
+                        id: 0
                     }
                 ],
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -547,19 +565,24 @@ fn test_repeat_with_missing_semicolon_in_body() {
                         left: Box::new(ref_to("x")),
                         right: Box::new(Statement::LiteralInteger {
                             value: 3,
-                            location: SourceRange::undefined()
-                        })
+                            location: SourceRange::undefined(),
+                            id: 0
+                        }),
+                        id: 0
                     }],
                     condition: Box::new(Statement::BinaryExpression {
                         left: Box::new(ref_to("x")),
                         right: Box::new(ref_to("y")),
-                        operator: crate::ast::Operator::Equal
+                        operator: crate::ast::Operator::Equal,
+                        id: 0
                     }),
                     location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::Assignment {
                     left: Box::new(ref_to("y")),
-                    right: Box::new(ref_to("x"))
+                    right: Box::new(ref_to("x")),
+                    id: 0
                 }
             ]
         )
@@ -602,17 +625,21 @@ fn test_nested_repeat_with_missing_until_end_repeat() {
                         condition: Box::new(Statement::BinaryExpression {
                             left: Box::new(ref_to("x")),
                             right: Box::new(ref_to("y")),
-                            operator: crate::ast::Operator::Equal
+                            operator: crate::ast::Operator::Equal,
+                            id: 0
                         }),
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("y")),
-                        right: Box::new(ref_to("x"))
+                        right: Box::new(ref_to("x")),
+                        id: 0
                     }
                 ],
                 condition: Box::new(empty_stmt()),
                 location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -659,17 +686,21 @@ fn test_nested_repeat_with_missing_condition_and_end_repeat() {
                         condition: Box::new(Statement::BinaryExpression {
                             left: Box::new(ref_to("x")),
                             right: Box::new(ref_to("y")),
-                            operator: crate::ast::Operator::Equal
+                            operator: crate::ast::Operator::Equal,
+                            id: 0
                         }),
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("y")),
-                        right: Box::new(ref_to("x"))
+                        right: Box::new(ref_to("x")),
+                        id: 0
                     }
                 ],
                 condition: Box::new(empty_stmt()),
                 location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -712,21 +743,26 @@ fn test_nested_repeat_with_missing_end_repeat() {
                         condition: Box::new(Statement::BinaryExpression {
                             left: Box::new(ref_to("x")),
                             right: Box::new(ref_to("y")),
-                            operator: crate::ast::Operator::Equal
+                            operator: crate::ast::Operator::Equal,
+                            id: 0
                         }),
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("y")),
-                        right: Box::new(ref_to("x"))
+                        right: Box::new(ref_to("x")),
+                        id: 0
                     }
                 ],
                 condition: Box::new(Statement::BinaryExpression {
                     left: Box::new(ref_to("x")),
                     right: Box::new(ref_to("y")),
-                    operator: crate::ast::Operator::Equal
+                    operator: crate::ast::Operator::Equal,
+                    id: 0
                 }),
                 location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -766,19 +802,24 @@ fn test_while_with_missing_semicolon_in_body() {
                         left: Box::new(ref_to("x")),
                         right: Box::new(Statement::LiteralInteger {
                             value: 3,
-                            location: SourceRange::undefined()
-                        })
+                            location: SourceRange::undefined(),
+                            id: 0
+                        }),
+                        id: 0
                     }],
                     condition: Box::new(Statement::BinaryExpression {
                         left: Box::new(ref_to("x")),
                         right: Box::new(ref_to("y")),
-                        operator: crate::ast::Operator::Equal
+                        operator: crate::ast::Operator::Equal,
+                        id: 0
                     }),
                     location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::Assignment {
                     left: Box::new(ref_to("y")),
-                    right: Box::new(ref_to("x"))
+                    right: Box::new(ref_to("x")),
+                    id: 0
                 }
             ]
         )
@@ -821,21 +862,26 @@ fn test_nested_while_with_missing_end_while() {
                         condition: Box::new(Statement::BinaryExpression {
                             left: Box::new(ref_to("x")),
                             right: Box::new(ref_to("y")),
-                            operator: crate::ast::Operator::Equal
+                            operator: crate::ast::Operator::Equal,
+                            id: 0
                         }),
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("y")),
-                        right: Box::new(ref_to("x"))
+                        right: Box::new(ref_to("x")),
+                        id: 0
                     }
                 ],
                 condition: Box::new(Statement::BinaryExpression {
                     left: Box::new(ref_to("x")),
                     right: Box::new(ref_to("y")),
-                    operator: crate::ast::Operator::Equal
+                    operator: crate::ast::Operator::Equal,
+                    id: 0
                 }),
                 location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -867,14 +913,17 @@ fn test_while_with_missing_do() {
             vec![Statement::WhileLoopStatement {
                 body: vec![Statement::Assignment {
                     left: Box::new(ref_to("y")),
-                    right: Box::new(ref_to("x"))
+                    right: Box::new(ref_to("x")),
+                    id: 0
                 }],
                 condition: Box::new(Statement::BinaryExpression {
                     left: Box::new(ref_to("x")),
                     right: Box::new(ref_to("y")),
-                    operator: crate::ast::Operator::Equal
+                    operator: crate::ast::Operator::Equal,
+                    id: 0
                 }),
                 location: SourceRange::undefined(),
+                id: 0
             }]
         )
     );
@@ -914,10 +963,12 @@ fn test_case_body_with_missing_semicolon() {
                     body: vec![Statement::Assignment {
                         left: Box::new(ref_to("y")),
                         right: Box::new(ref_to("z")),
+                        id: 0
                     }],
                 },],
                 else_block: vec![],
                 location: SourceRange::undefined(),
+                id: 0
             }]
         )
     );

--- a/src/parser/tests/statement_parser_tests.rs
+++ b/src/parser/tests/statement_parser_tests.rs
@@ -16,16 +16,20 @@ fn empty_statements_are_are_parsed() {
             "{:?}",
             vec![
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
             ]
         ),
@@ -45,20 +49,25 @@ fn empty_statements_are_parsed_before_a_statement() {
             "{:?}",
             vec![
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::Reference {
                     name: "x".into(),
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
             ]
         ),

--- a/src/parser/tests/type_parser_tests.rs
+++ b/src/parser/tests/type_parser_tests.rs
@@ -121,11 +121,14 @@ fn array_type_can_be_parsed_test() {
                     start: Box::new(Statement::LiteralInteger {
                         value: 0,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
                     end: Box::new(Statement::LiteralInteger {
                         value: 8,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
+                    id: 0,
                 },
                 referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                     referenced_type: "INT".to_string(),
@@ -157,6 +160,7 @@ fn string_type_can_be_parsed_test() {
                     size: Some(LiteralInteger {
                         value: 253,
                         location: (10..11).into(),
+                        id: 0,
                     }),
                     is_wide: false,
                 },
@@ -168,6 +172,7 @@ fn string_type_can_be_parsed_test() {
                     size: Some(LiteralInteger {
                         value: 253,
                         location: (10..11).into(),
+                        id: 0,
                     }),
                     is_wide: false,
                 },
@@ -175,6 +180,7 @@ fn string_type_can_be_parsed_test() {
                     is_wide: false,
                     location: SourceRange::undefined(),
                     value: "abc".into(),
+                    id: 0,
                 }),
             }
         ]
@@ -200,6 +206,7 @@ fn wide_string_type_can_be_parsed_test() {
                 size: Some(LiteralInteger {
                     value: 253,
                     location: (10..11).into(),
+                    id: 0,
                 }),
                 is_wide: true,
             },
@@ -229,11 +236,14 @@ fn subrangetype_can_be_parsed() {
                     start: Box::new(LiteralInteger {
                         value: 0,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
                     end: Box::new(LiteralInteger {
                         value: 1000,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
+                    id: 0,
                 }),
                 referenced_type: "UINT".to_string(),
             },


### PR DESCRIPTION
add IDs to Statements 
this is a preparation for implementing an annotated parse tree 
used in semantic analysis

also improved some test-coverage for get_id(), and get_location() in statements