### PR TITLE
Literals type annotation

### DIFF
--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -246,6 +246,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
             let left = Statement::Reference {
                 name: variable.get_name().into(),
                 location: variable.source_location.clone(),
+                id: 0, //TODO
             };
             let right = variable.initial_value.as_ref().unwrap();
             statement_generator.generate_assignment_statement(&left, right)?;
@@ -268,6 +269,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
                 let reference = Statement::Reference {
                     name: function_context.linking_context.get_call_name().into(),
                     location: location.unwrap_or_else(SourceRange::undefined),
+                    id: 0, //TODO
                 };
                 let mut exp_gen = ExpressionCodeGenerator::new(
                     &self.llvm,

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -91,7 +91,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             Statement::EmptyStatement { .. } => {
                 //nothing to generate
             }
-            Statement::Assignment { left, right } => {
+            Statement::Assignment { left, right, .. } => {
                 self.generate_assignment_statement(left, right)?;
             }
             Statement::ForLoopStatement {
@@ -127,7 +127,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             } => {
                 self.generate_case_statement(selector, case_blocks, else_block)?;
             }
-            Statement::ReturnStatement { location } => {
+            Statement::ReturnStatement { location, .. } => {
                 self.pou_generator.generate_return_statement(
                     self.function_context,
                     self.llvm_index,
@@ -273,6 +273,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
                 expression_generator.generate_literal(&Statement::LiteralInteger {
                     value: 1,
                     location: end.get_location(),
+                    id: 0, //TODO
                 })
             },
             |step| expression_generator.generate_expression(&step),
@@ -348,7 +349,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             //flatten the expression list into a vector of expressions
             let expressions = flatten_expression_list(&*conditional_block.condition);
             for s in expressions {
-                if let Statement::RangeStatement { start, end } = s {
+                if let Statement::RangeStatement { start, end, .. } = s {
                     //if this is a range statement, we generate an if (x >= start && x <= end) then the else-section
                     builder.position_at_end(current_else_block);
                     // since the if's generate additional blocks, we use the last one as the else-section
@@ -626,10 +627,13 @@ fn create_call_to_check_function_ast(
         operator: Box::new(Statement::Reference {
             name: check_function_name,
             location: location.clone(),
+            id: 0, //TODO
         }),
         parameters: Box::new(Some(Statement::ExpressionList {
             expressions: vec![parameter, sub_range.start, sub_range.end],
+            id: 0, //TODO
         })),
         location: location.clone(),
+        id: 0, //TODO
     }
 }

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -195,7 +195,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
         &self,
         data_type: &DataTypeInformation,
     ) -> Option<&ImplementationIndexEntry> {
-        let effective_type = self.index.find_effective_type(data_type);
+        let effective_type = self.index.find_effective_type_information(data_type);
         match effective_type {
             Some(DataTypeInformation::Integer { signed, size, .. }) if *signed && *size <= 32 => {
                 self.index.find_implementation(RANGE_CHECK_S_FN)

--- a/src/codegen/llvm_typesystem.rs
+++ b/src/codegen/llvm_typesystem.rs
@@ -159,18 +159,22 @@ pub fn cast_if_needed<'ctx>(
     location_context: &Statement,
 ) -> Result<BasicValueEnum<'ctx>, CompileError> {
     let builder = &llvm.builder;
-    let target_type = index.find_effective_type_information(target_type).ok_or_else(|| {
-        CompileError::codegen_error(
-            format!("Could not find primitive type for {:?}", target_type),
-            SourceRange::undefined(),
-        )
-    })?;
-    let value_type = index.find_effective_type_information(value_type).ok_or_else(|| {
-        CompileError::codegen_error(
-            format!("Could not find primitive type for {:?}", value_type),
-            SourceRange::undefined(),
-        )
-    })?;
+    let target_type = index
+        .find_effective_type_information(target_type)
+        .ok_or_else(|| {
+            CompileError::codegen_error(
+                format!("Could not find primitive type for {:?}", target_type),
+                SourceRange::undefined(),
+            )
+        })?;
+    let value_type = index
+        .find_effective_type_information(value_type)
+        .ok_or_else(|| {
+            CompileError::codegen_error(
+                format!("Could not find primitive type for {:?}", value_type),
+                SourceRange::undefined(),
+            )
+        })?;
     match target_type {
         DataTypeInformation::Integer {
             signed,

--- a/src/codegen/llvm_typesystem.rs
+++ b/src/codegen/llvm_typesystem.rs
@@ -28,8 +28,8 @@ pub fn promote_if_needed<'a>(
     let (rtype, rvalue) = rvalue;
 
     //TODO : We need better error handling here
-    let ltype = index.find_effective_type(ltype).unwrap();
-    let rtype = index.find_effective_type(rtype).unwrap();
+    let ltype = index.find_effective_type_information(ltype).unwrap();
+    let rtype = index.find_effective_type_information(rtype).unwrap();
 
     let ltype_llvm = llvm_index.find_associated_type(ltype.get_name()).unwrap();
     let rtype_llvm = llvm_index.find_associated_type(rtype.get_name()).unwrap();
@@ -159,13 +159,13 @@ pub fn cast_if_needed<'ctx>(
     location_context: &Statement,
 ) -> Result<BasicValueEnum<'ctx>, CompileError> {
     let builder = &llvm.builder;
-    let target_type = index.find_effective_type(target_type).ok_or_else(|| {
+    let target_type = index.find_effective_type_information(target_type).ok_or_else(|| {
         CompileError::codegen_error(
             format!("Could not find primitive type for {:?}", target_type),
             SourceRange::undefined(),
         )
     })?;
-    let value_type = index.find_effective_type(value_type).ok_or_else(|| {
+    let value_type = index.find_effective_type_information(value_type).ok_or_else(|| {
         CompileError::codegen_error(
             format!("Could not find primitive type for {:?}", value_type),
             SourceRange::undefined(),

--- a/src/index.rs
+++ b/src/index.rs
@@ -234,6 +234,17 @@ impl Index {
         self.types.get(type_name)
     }
 
+    pub fn find_effective_type_by_name(&self, type_name: &str) -> Option<&DataType> {
+        self.find_type(type_name)
+            .and_then(|it| self.find_effective_type(it))
+    }
+
+    pub fn get_effective_type_by_name(&self, type_name: &str) -> &DataType {
+        self.find_type(type_name)
+            .and_then(|it| self.find_effective_type(it))
+            .unwrap_or(&self.void_type)
+    }
+
     pub fn get_type(&self, type_name: &str) -> Result<&DataType, CompileError> {
         self.find_type(type_name)
             .ok_or_else(|| CompileError::unknown_type(type_name, SourceRange::undefined()))

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,7 +1,11 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use indexmap::IndexMap;
 
-use crate::{ast::{Implementation, SourceRange, Statement}, compile_error::CompileError, typesystem::*};
+use crate::{
+    ast::{Implementation, SourceRange, Statement},
+    compile_error::CompileError,
+    typesystem::*,
+};
 
 #[cfg(test)]
 mod tests;
@@ -235,7 +239,6 @@ impl Index {
             .ok_or_else(|| CompileError::unknown_type(type_name, SourceRange::undefined()))
     }
 
-
     /// Retrieves the "Effective" type behind this datatype
     /// An effective type will be any end type i.e. Structs, Integers, Floats, String and Array
     pub fn find_effective_type<'ret>(
@@ -256,7 +259,6 @@ impl Index {
             _ => Some(data_type),
         }
     }
-
 
     /// Retrieves the "Effective" type-information behind this datatype
     /// An effective type will be any end type i.e. Structs, Integers, Floats, String and Array

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -87,7 +87,7 @@ fn actions_are_indexed() {
         panic!("Wrong variant : {:#?}", info);
     }
     if let crate::typesystem::DataTypeInformation::Struct { name, .. } =
-        index.find_effective_type(info).unwrap()
+        index.find_effective_type_information(info).unwrap()
     {
         assert_eq!("myProgram_interface", name);
     } else {
@@ -113,7 +113,7 @@ fn actions_are_indexed() {
         panic!("Wrong variant : {:#?}", info);
     }
     if let crate::typesystem::DataTypeInformation::Struct { name, .. } =
-        index.find_effective_type(info).unwrap()
+        index.find_effective_type_information(info).unwrap()
     {
         assert_eq!("myProgram_interface", name);
     } else {
@@ -603,25 +603,25 @@ fn find_effective_type_finds_the_inner_effective_type() {
     );
 
     let my_alias = index.find_type("MyAlias").unwrap().get_type_information();
-    let int = index.find_effective_type(&my_alias).unwrap();
+    let int = index.find_effective_type_information(&my_alias).unwrap();
     assert_eq!("INT", int.get_name());
 
     let my_alias = index
         .find_type("MySecondAlias")
         .unwrap()
         .get_type_information();
-    let int = index.find_effective_type(&my_alias).unwrap();
+    let int = index.find_effective_type_information(&my_alias).unwrap();
     assert_eq!("INT", int.get_name());
 
     let my_alias = index
         .find_type("MyArrayAlias")
         .unwrap()
         .get_type_information();
-    let array = index.find_effective_type(&my_alias).unwrap();
+    let array = index.find_effective_type_information(&my_alias).unwrap();
     assert_eq!("MyArray", array.get_name());
 
     let my_alias = index.find_type("MyArray").unwrap().get_type_information();
-    let array = index.find_effective_type(&my_alias).unwrap();
+    let array = index.find_effective_type_information(&my_alias).unwrap();
     assert_eq!("MyArray", array.get_name());
 }
 

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -827,11 +827,14 @@ fn pre_processing_generates_inline_arrays() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "INT".to_string(),
@@ -878,11 +881,14 @@ fn pre_processing_generates_inline_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "INT".to_string(),
@@ -901,11 +907,14 @@ fn pre_processing_generates_inline_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "__foo_inline_array_".to_string(),
@@ -976,11 +985,14 @@ fn pre_processing_nested_array_in_struct() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 4,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "INT".to_string(),
@@ -1018,11 +1030,14 @@ fn pre_processing_generates_inline_array_of_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "INT".to_string(),
@@ -1041,11 +1056,14 @@ fn pre_processing_generates_inline_array_of_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "__foo_inline_array__".to_string(),
@@ -1064,11 +1082,14 @@ fn pre_processing_generates_inline_array_of_array_of_array() {
                 start: Box::new(Statement::LiteralInteger {
                     value: 0,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 1,
                     location: SourceRange::undefined(),
+                    id: 0,
                 }),
+                id: 0,
             },
             referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                 referenced_type: "__foo_inline_array_".to_string(),
@@ -1106,9 +1127,11 @@ fn sub_range_boundaries_are_registered_at_the_index() {
         sub_range: Statement::LiteralInteger {
             value: 7,
             location: SourceRange::undefined(),
+            id: 0,
         }..Statement::LiteralInteger {
             value: 1000,
             location: SourceRange::undefined(),
+            id: 0,
         },
     };
 

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -247,6 +247,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                     Some(ast::Statement::LiteralInteger {
                         value: i as i64,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
                     SourceRange::undefined(),
                 )
@@ -258,7 +259,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
             referenced_type,
             bounds,
         } => {
-            let information = if let Some(Statement::RangeStatement { start, end }) = bounds {
+            let information = if let Some(Statement::RangeStatement { start, end, .. }) = bounds {
                 DataTypeInformation::SubRange {
                     name: name.as_ref().unwrap().into(),
                     referenced_type: referenced_type.into(),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -5,6 +5,7 @@ use logos::Lexer;
 use logos::Logos;
 pub use tokens::Token;
 
+use crate::ast::AstId;
 use crate::ast::SourceRange;
 use crate::Diagnostic;
 
@@ -22,6 +23,7 @@ pub struct ParseSession<'a> {
     /// the range of the `last_token`
     pub last_range: Range<usize>,
     pub parse_progress: usize,
+    current_id: AstId,
 }
 
 #[macro_export]
@@ -48,9 +50,15 @@ impl<'a> ParseSession<'a> {
             last_token: Token::End,
             last_range: 0..0,
             parse_progress: 0,
+            current_id: 0,
         };
         lexer.advance();
         lexer
+    }
+
+    pub fn next_id(&mut self) -> AstId {
+        self.current_id += 1;
+        self.current_id
     }
 
     /// this function will be removed soon:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use inkwell::targets::{
     CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine, TargetTriple,
 };
 use parser::ParsedAst;
+use resolver::TypeAnnotator;
 use std::{fs::File, io::Read};
 
 use crate::ast::CompilationUnit;
@@ -45,6 +46,7 @@ pub mod index;
 mod lexer;
 mod parser;
 mod typesystem;
+mod resolver;
 
 #[macro_use]
 extern crate pretty_assertions;
@@ -320,6 +322,7 @@ pub fn compile_module<'c, T: SourceContainer>(
     let mut unit = CompilationUnit::default();
     // let mut diagnostics : Vec<Diagnostic> = vec![];
     let mut files: SimpleFiles<String, String> = SimpleFiles::new();
+    let mut all_units = Vec::new();
     for container in sources {
         let location: String = container.get_location().into();
         let e = container
@@ -327,9 +330,11 @@ pub fn compile_module<'c, T: SourceContainer>(
             .map_err(|err| CompileError::io_read_error(err, location.clone()))?;
 
         let (mut parse_result, diagnostics) = parse(e.source.as_str());
+        //pre-process the ast (create inlined types)
         ast::pre_process(&mut parse_result);
+        //index the pou
         full_index.import(index::visitor::visit(&parse_result));
-        unit.import(parse_result);
+        all_units.push(parse_result);
 
         //log errors
         let file_id = files.add(location, e.source.clone());
@@ -357,6 +362,13 @@ pub fn compile_module<'c, T: SourceContainer>(
                 )
             })?;
         }
+    }
+
+    //annotate the ASTs
+    for u in all_units {
+        let mut ta = TypeAnnotator::new(&full_index);
+        ta.visit_unit(&u);
+        unit.import(u);  //TODO this needs to be changed so we have unique AstIds
     }
 
     //and finally codegen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@ pub mod compile_error;
 pub mod index;
 mod lexer;
 mod parser;
-mod typesystem;
 mod resolver;
+mod typesystem;
 
 #[macro_use]
 extern crate pretty_assertions;
@@ -368,7 +368,7 @@ pub fn compile_module<'c, T: SourceContainer>(
     for u in all_units {
         let mut ta = TypeAnnotator::new(&full_index);
         ta.visit_unit(&u);
-        unit.import(u);  //TODO this needs to be changed so we have unique AstIds
+        unit.import(u); //TODO this needs to be changed so we have unique AstIds
     }
 
     //and finally codegen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,8 +366,8 @@ pub fn compile_module<'c, T: SourceContainer>(
 
     //annotate the ASTs
     for u in all_units {
-        let mut ta = TypeAnnotator::new(&full_index);
-        ta.visit_unit(&u);
+        let _type_map = TypeAnnotator::visit_unit(&full_index, &u);
+        //TODO validate and find solution for type_map
         unit.import(u); //TODO this needs to be changed so we have unique AstIds
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -693,6 +693,7 @@ fn parse_statement(lexer: &mut ParseSession) -> Statement {
     if lexer.last_token == KeywordColon {
         Statement::CaseCondition {
             condition: Box::new(result),
+            id: lexer.next_id(),
         }
     } else {
         result
@@ -721,6 +722,7 @@ fn parse_reference(lexer: &mut ParseSession) -> Statement {
         Err(diagnostic) => {
             let statement = Statement::EmptyStatement {
                 location: diagnostic.get_location(),
+                id: lexer.next_id(),
             };
             lexer.accept_diagnostic(diagnostic);
             statement

--- a/src/parser/control_parser.rs
+++ b/src/parser/control_parser.rs
@@ -25,7 +25,10 @@ pub fn parse_control_statement(lexer: &mut ParseSession) -> Statement {
 fn parse_return_statement(lexer: &mut ParseSession) -> Statement {
     let location = lexer.location();
     lexer.advance();
-    Statement::ReturnStatement { location }
+    Statement::ReturnStatement {
+        location,
+        id: lexer.next_id(),
+    }
 }
 
 fn parse_if_statement(lexer: &mut ParseSession) -> Statement {
@@ -40,6 +43,7 @@ fn parse_if_statement(lexer: &mut ParseSession) -> Statement {
             KeywordThen,
             Statement::EmptyStatement {
                 location: lexer.location(),
+                id: lexer.next_id()
             }
         );
         lexer.advance();
@@ -64,6 +68,7 @@ fn parse_if_statement(lexer: &mut ParseSession) -> Statement {
         blocks: conditional_blocks,
         else_block,
         location: SourceRange::new(start..end),
+        id: lexer.next_id(),
     }
 }
 
@@ -77,6 +82,7 @@ fn parse_for_statement(lexer: &mut ParseSession) -> Statement {
         KeywordAssignment,
         Statement::EmptyStatement {
             location: lexer.location(),
+            id: lexer.next_id()
         }
     );
     lexer.advance();
@@ -87,6 +93,7 @@ fn parse_for_statement(lexer: &mut ParseSession) -> Statement {
         KeywordTo,
         Statement::EmptyStatement {
             location: lexer.location(),
+            id: lexer.next_id(),
         }
     );
     lexer.advance();
@@ -108,6 +115,7 @@ fn parse_for_statement(lexer: &mut ParseSession) -> Statement {
         by_step: step,
         body: parse_body_in_region(lexer, vec![KeywordEndFor]),
         location: SourceRange::new(start..lexer.last_range.end),
+        id: lexer.next_id(),
     }
 }
 
@@ -122,6 +130,7 @@ fn parse_while_statement(lexer: &mut ParseSession) -> Statement {
         condition: Box::new(condition),
         body: parse_body_in_region(lexer, vec![KeywordEndWhile]),
         location: SourceRange::new(start..lexer.last_range.end),
+        id: lexer.next_id(),
     }
 }
 
@@ -137,6 +146,7 @@ fn parse_repeat_statement(lexer: &mut ParseSession) -> Statement {
     } else {
         Statement::EmptyStatement {
             location: lexer.location(),
+            id: lexer.next_id(),
         }
     };
 
@@ -144,6 +154,7 @@ fn parse_repeat_statement(lexer: &mut ParseSession) -> Statement {
         condition: Box::new(condition),
         body,
         location: SourceRange::new(start..lexer.range().end),
+        id: lexer.next_id(),
     }
 }
 
@@ -158,6 +169,7 @@ fn parse_case_statement(lexer: &mut ParseSession) -> Statement {
         KeywordOf,
         Statement::EmptyStatement {
             location: lexer.location(),
+            id: lexer.next_id()
         }
     );
 
@@ -170,7 +182,7 @@ fn parse_case_statement(lexer: &mut ParseSession) -> Statement {
         let mut current_condition = None;
         let mut current_body = vec![];
         for statement in body {
-            if let Statement::CaseCondition { condition } = statement {
+            if let Statement::CaseCondition { condition, .. } = statement {
                 if let Some(condition) = current_condition {
                     let block = ConditionalBlock {
                         condition,
@@ -189,6 +201,7 @@ fn parse_case_statement(lexer: &mut ParseSession) -> Statement {
                     ));
                     current_condition = Some(Box::new(Statement::EmptyStatement {
                         location: lexer.location(),
+                        id: lexer.next_id(),
                     }));
                 }
                 current_body.push(statement);
@@ -215,5 +228,6 @@ fn parse_case_statement(lexer: &mut ParseSession) -> Statement {
         case_blocks,
         else_block,
         location: SourceRange::new(start..end),
+        id: lexer.next_id(),
     }
 }

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -201,11 +201,23 @@ fn parse_unary_expression(lexer: &mut ParseSession) -> Statement {
         let expression = parse_parenthesized_expression(lexer);
         let expression_location = expression.get_location();
         let location = SourceRange::new(start..expression_location.get_end());
-        Statement::UnaryExpression {
-            operator,
-            value: Box::new(expression),
-            location,
-            id: lexer.next_id(),
+
+        if let (Statement::LiteralInteger { value, .. }, Operator::Minus) = (&expression, &operator)
+        {
+            //if this turns out to be a negative number, we want to have a negative literal integer
+            //instead of a Unary-Not-Expression
+            Statement::LiteralInteger {
+                value: -value,
+                location,
+                id: lexer.next_id(),
+            }
+        } else {
+            Statement::UnaryExpression {
+                operator,
+                value: Box::new(expression),
+                location,
+                id: lexer.next_id(),
+            }
         }
     } else {
         parse_parenthesized_expression(lexer)

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -23,6 +23,7 @@ pub fn ref_to(name: &str) -> Statement {
     Statement::Reference {
         location: SourceRange::undefined(),
         name: name.to_string(),
+        id: 0,
     }
 }
 
@@ -30,5 +31,6 @@ pub fn ref_to(name: &str) -> Statement {
 pub fn empty_stmt() -> Statement {
     Statement::EmptyStatement {
         location: SourceRange::undefined(),
+        id: 0,
     }
 }

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -28,17 +28,22 @@ fn qualified_reference_statement_parsed() {
 
     if let Statement::QualifiedReference { elements, .. } = statement {
         assert_eq!(
-            elements,
-            &[
-                Statement::Reference {
-                    name: "a".to_string(),
-                    location: (12..13).into()
-                },
-                Statement::Reference {
-                    name: "x".to_string(),
-                    location: (14..15).into()
-                },
-            ]
+            format!("{:?}", elements),
+            format!(
+                "{:?}",
+                &[
+                    Statement::Reference {
+                        name: "a".to_string(),
+                        location: (12..13).into(),
+                        id: 0
+                    },
+                    Statement::Reference {
+                        name: "x".to_string(),
+                        location: (14..15).into(),
+                        id: 0
+                    },
+                ]
+            )
         );
     } else {
         panic!("Expected Reference but found {:?}", statement);
@@ -53,7 +58,7 @@ fn literal_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(7 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -68,7 +73,7 @@ fn literal_binary_with_underscore_number_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(45 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -83,7 +88,7 @@ fn literal_hex_number_with_underscores_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(3735928559 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -98,7 +103,7 @@ fn literal_hex_number_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(3735928559 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -113,7 +118,7 @@ fn literal_oct_number_with_underscores_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(63 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -128,7 +133,7 @@ fn literal_dec_number_with_underscores_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(43000 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -143,7 +148,7 @@ fn literal_oct_number_with_underscore_can_be_parsed() {
     let prg = &result.implementations[0];
     let statement = &prg.statements[0];
 
-    if let Statement::LiteralInteger { value, location: _ } = statement {
+    if let Statement::LiteralInteger { value, .. } = statement {
         assert_eq!(value, &(63 as i64));
     } else {
         panic!("Expected LiteralInteger but found {:?}", statement);
@@ -162,6 +167,7 @@ fn additon_of_two_variables_parsed() {
         operator,
         left,  //Box<Reference> {name : left}),
         right, //Box<Reference> {name : right}),
+        ..
     } = statement
     {
         if let Statement::Reference { name, .. } = &**left {
@@ -188,6 +194,7 @@ fn additon_of_three_variables_parsed() {
         operator,
         left,  //Box<Reference> {name : left}),
         right, //Box<Reference> {name : right}),
+        ..
     } = statement
     {
         assert_eq!(operator, &Operator::Plus);
@@ -198,6 +205,7 @@ fn additon_of_three_variables_parsed() {
             operator,
             left,
             right,
+            ..
         } = &**right
         {
             if let Statement::Reference { name, .. } = &**left {
@@ -227,6 +235,7 @@ fn parenthesis_expressions_should_not_change_the_ast() {
         operator,
         left,
         right,
+        ..
     } = statement
     {
         if let Statement::Reference { name, .. } = &**left {

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -710,11 +710,8 @@ fn signed_literal_minus_test() {
     let statement = &prg.statements[0];
 
     let ast_string = format!("{:#?}", statement);
-    let expected_ast = r#"UnaryExpression {
-    operator: Minus,
-    value: LiteralInteger {
-        value: 1,
-    },
+    let expected_ast = r#"LiteralInteger {
+    value: -1,
 }"#;
     assert_eq!(ast_string, expected_ast);
 }
@@ -1047,11 +1044,8 @@ fn signed_literal_expression_reversed_test() {
     let ast_string = format!("{:#?}", statement);
     let expected_ast = r#"BinaryExpression {
     operator: Plus,
-    left: UnaryExpression {
-        operator: Minus,
-        value: LiteralInteger {
-            value: 4,
-        },
+    left: LiteralInteger {
+        value: -4,
     },
     right: LiteralInteger {
         value: 5,
@@ -1374,17 +1368,11 @@ fn negative_range_expression() {
 
     let ast_string = format!("{:#?}", statement);
     let expected_ast = r#"RangeStatement {
-    start: UnaryExpression {
-        operator: Minus,
-        value: LiteralInteger {
-            value: 2,
-        },
+    start: LiteralInteger {
+        value: -2,
     },
-    end: UnaryExpression {
-        operator: Minus,
-        value: LiteralInteger {
-            value: 1,
-        },
+    end: LiteralInteger {
+        value: -1,
     },
 }"#;
 
@@ -1407,17 +1395,11 @@ fn negative_range_expression_space() {
 
     let ast_string = format!("{:#?}", statement);
     let expected_ast = r#"RangeStatement {
-    start: UnaryExpression {
-        operator: Minus,
-        value: LiteralInteger {
-            value: 2,
-        },
+    start: LiteralInteger {
+        value: -2,
     },
-    end: UnaryExpression {
-        operator: Minus,
-        value: LiteralInteger {
-            value: 1,
-        },
+    end: LiteralInteger {
+        value: -1,
     },
 }"#;
 

--- a/src/parser/tests/misc_parser_tests.rs
+++ b/src/parser/tests/misc_parser_tests.rs
@@ -1,3 +1,5 @@
+use core::panic;
+
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::{
     ast::*,
@@ -17,4 +19,384 @@ fn programs_can_be_external() {
     let parse_result = parse(lexer).0;
     let implementation = &parse_result.implementations[0];
     assert_eq!(LinkageType::External, implementation.linkage);
+}
+
+#[test]
+fn ids_are_assigned_to_parsed_literals() {
+    let lexer = lex("
+    PROGRAM PRG
+        ;
+        (* literals *)
+        1;
+        D#2021-10-01;
+        DT#2021-10-01-20:15:00;
+        TOD#23:59:59.999;
+        TIME#2d4h6m8s10ms;
+        3.1415;
+        TRUE;
+        'abc';
+        [1,2,3];
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    assert_eq!(implementation.statements[0].get_id(), 1);
+    assert_eq!(implementation.statements[1].get_id(), 2);
+    assert_eq!(implementation.statements[2].get_id(), 3);
+    assert_eq!(implementation.statements[3].get_id(), 4);
+    assert_eq!(implementation.statements[4].get_id(), 5);
+    assert_eq!(implementation.statements[5].get_id(), 6);
+    assert_eq!(implementation.statements[6].get_id(), 7);
+    assert_eq!(implementation.statements[7].get_id(), 8);
+    assert_eq!(implementation.statements[8].get_id(), 9);
+}
+
+#[test]
+fn ids_are_assigned_to_parsed_assignments() {
+    let lexer = lex("
+    PROGRAM PRG
+        a := b;
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    if let Statement::Assignment { id, left, right } = &implementation.statements[0] {
+        assert_eq!(left.get_id(), 1);
+        assert_eq!(right.get_id(), 2);
+        assert_eq!(*id, 3);
+    } else {
+        panic!("unexpected statement");
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_callstatements() {
+    let lexer = lex("
+    PROGRAM PRG
+        foo();
+        foo(1,2,3);
+        foo(a := 1, b => c, d);
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    if let Statement::CallStatement { id, operator, .. } = &implementation.statements[0] {
+        assert_eq!(operator.get_id(), 1);
+        assert_eq!(*id, 2);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::CallStatement {
+        id,
+        operator,
+        parameters,
+        ..
+    } = &implementation.statements[1]
+    {
+        assert_eq!(operator.get_id(), 3);
+        if let Some(Statement::ExpressionList { expressions, id }) = &**parameters {
+            assert_eq!(expressions[0].get_id(), 4);
+            assert_eq!(expressions[1].get_id(), 5);
+            assert_eq!(expressions[2].get_id(), 6);
+            assert_eq!(*id, 7);
+        }
+        assert_eq!(*id, 8);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::CallStatement {
+        id,
+        operator,
+        parameters,
+        ..
+    } = &implementation.statements[2]
+    {
+        assert_eq!(operator.get_id(), 9);
+        if let Some(Statement::ExpressionList { expressions, id }) = &**parameters {
+            if let Statement::Assignment {
+                left, right, id, ..
+            } = &expressions[0]
+            {
+                assert_eq!(left.get_id(), 10);
+                assert_eq!(right.get_id(), 11);
+                assert_eq!(*id, 12);
+            } else {
+                panic!("unexpected statement");
+            }
+            if let Statement::OutputAssignment {
+                left, right, id, ..
+            } = &expressions[1]
+            {
+                assert_eq!(left.get_id(), 13);
+                assert_eq!(right.get_id(), 14);
+                assert_eq!(*id, 15);
+            } else {
+                panic!("unexpected statement");
+            }
+            assert_eq!(expressions[2].get_id(), 16);
+            assert_eq!(*id, 17);
+        }
+        assert_eq!(*id, 18);
+    } else {
+        panic!("unexpected statement");
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_expressions() {
+    let lexer = lex("
+    PROGRAM PRG
+        a * b;
+        a.b;
+        a;
+        a[2];
+        -b;
+        a,b;
+        1..2;
+        5(a);
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    if let Statement::BinaryExpression {
+        id, left, right, ..
+    } = &implementation.statements[0]
+    {
+        assert_eq!(left.get_id(), 1);
+        assert_eq!(right.get_id(), 2);
+        assert_eq!(*id, 3);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::QualifiedReference { id, elements, .. } = &implementation.statements[1] {
+        assert_eq!(elements[0].get_id(), 4);
+        assert_eq!(elements[1].get_id(), 5);
+        assert_eq!(*id, 6);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::Reference { id, .. } = &implementation.statements[2] {
+        assert_eq!(*id, 7);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::ArrayAccess {
+        id,
+        reference,
+        access,
+        ..
+    } = &implementation.statements[3]
+    {
+        assert_eq!(reference.get_id(), 8);
+        assert_eq!(access.get_id(), 9);
+        assert_eq!(*id, 10);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::UnaryExpression { id, value, .. } = &implementation.statements[4] {
+        assert_eq!(value.get_id(), 11);
+        assert_eq!(*id, 12);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::ExpressionList {
+        id, expressions, ..
+    } = &implementation.statements[5]
+    {
+        assert_eq!(expressions[0].get_id(), 13);
+        assert_eq!(expressions[1].get_id(), 14);
+        assert_eq!(*id, 15);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::RangeStatement { id, start, end, .. } = &implementation.statements[6] {
+        assert_eq!(start.get_id(), 16);
+        assert_eq!(end.get_id(), 17);
+        assert_eq!(*id, 18);
+    } else {
+        panic!("unexpected statement");
+    }
+
+    if let Statement::MultipliedStatement { id, element, .. } = &implementation.statements[7] {
+        assert_eq!(element.get_id(), 19);
+        assert_eq!(*id, 20);
+    } else {
+        panic!("unexpected statement");
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_if_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+        IF TRUE THEN
+            ;
+        ELSE    
+            ;
+        END_IF
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::IfStatement {
+            blocks, else_block, ..
+        } => {
+            assert_eq!(blocks[0].condition.get_id(), 1);
+            assert_eq!(blocks[0].body[0].get_id(), 2);
+            assert_eq!(else_block[0].get_id(), 3);
+            assert_eq!(implementation.statements[0].get_id(), 4);
+        }
+        _ => panic!("invalid statement"),
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_for_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+        FOR x := 1 TO 7 BY 2 DO
+            ;
+            ;
+            ;
+        END_FOR;
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::ForLoopStatement {
+            counter,
+            start,
+            end,
+            by_step,
+            id,
+            body,
+            ..
+        } => {
+            assert_eq!(counter.get_id(), 1);
+            assert_eq!(start.get_id(), 2);
+            assert_eq!(end.get_id(), 3);
+            assert_eq!(by_step.as_ref().unwrap().get_id(), 4);
+            assert_eq!(body[0].get_id(), 5);
+            assert_eq!(body[1].get_id(), 6);
+            assert_eq!(body[2].get_id(), 7);
+            assert_eq!(*id, 8);
+        }
+        _ => panic!("invalid statement"),
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_while_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+       WHILE TRUE DO
+            ;;
+        END_WHILE
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::WhileLoopStatement {
+            condition, body, ..
+        } => {
+            assert_eq!(condition.get_id(), 1);
+            assert_eq!(body[0].get_id(), 2);
+            assert_eq!(body[1].get_id(), 3);
+            assert_eq!(implementation.statements[0].get_id(), 4);
+        }
+        _ => panic!("invalid statement"),
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_repeat_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+       REPEAT
+            ;;
+       UNTIL TRUE END_REPEAT
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::RepeatLoopStatement {
+            condition, body, ..
+        } => {
+            assert_eq!(body[0].get_id(), 1);
+            assert_eq!(body[1].get_id(), 2);
+            assert_eq!(condition.get_id(), 3);
+            assert_eq!(implementation.statements[0].get_id(), 4);
+        }
+        _ => panic!("invalid statement"),
+    }
+}
+
+#[test]
+fn ids_are_assigned_to_case_statements() {
+    let lexer = lex("
+    PROGRAM PRG
+    CASE PumpState OF
+    0:
+        ;
+    1,2:
+        ;
+    ELSE
+        ;
+    END_CASE;
+    END_PROGRAM
+    ");
+    let parse_result = parse(lexer).0;
+    let implementation = &parse_result.implementations[0];
+
+    match &implementation.statements[0] {
+        Statement::CaseStatement {
+            case_blocks,
+            else_block,
+            selector,
+            ..
+        } => {
+            //1st case block
+            assert_eq!(selector.get_id(), 1);
+            assert_eq!(case_blocks[0].condition.get_id(), 2);
+            assert_eq!(case_blocks[0].body[0].get_id(), 4);
+
+            //2nd case block
+            if let Statement::ExpressionList {
+                expressions, id, ..
+            } = case_blocks[1].condition.as_ref()
+            {
+                assert_eq!(expressions[0].get_id(), 5);
+                assert_eq!(expressions[1].get_id(), 6);
+                assert_eq!(*id, 7);
+            } else {
+                panic!("expected expression list")
+            }
+            assert_eq!(case_blocks[1].body[0].get_id(), 9);
+
+            //else block
+            assert_eq!(else_block[0].get_id(), 10);
+        }
+
+        _ => panic!("invalid statement"),
+    }
 }

--- a/src/parser/tests/misc_parser_tests.rs
+++ b/src/parser/tests/misc_parser_tests.rs
@@ -1,9 +1,13 @@
 use core::panic;
+use std::ops::Range;
 
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::{
     ast::*,
-    parser::{parse, tests::lex},
+    parser::{
+        parse,
+        tests::{empty_stmt, lex},
+    },
 };
 use pretty_assertions::*;
 
@@ -399,4 +403,571 @@ fn ids_are_assigned_to_case_statements() {
 
         _ => panic!("invalid statement"),
     }
+}
+
+#[test]
+fn id_implementation_for_all_statements() {
+    assert_eq!(
+        Statement::ArrayAccess {
+            access: Box::new(empty_stmt()),
+            reference: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::Assignment {
+            left: Box::new(empty_stmt()),
+            right: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::BinaryExpression {
+            left: Box::new(empty_stmt()),
+            right: Box::new(empty_stmt()),
+            operator: Operator::And,
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::BinaryExpression {
+            left: Box::new(empty_stmt()),
+            right: Box::new(empty_stmt()),
+            operator: Operator::And,
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::CallStatement {
+            operator: Box::new(empty_stmt()),
+            parameters: Box::new(None),
+            id: 7,
+            location: (1..5).into()
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::CaseCondition {
+            condition: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::CaseStatement {
+            selector: Box::new(empty_stmt()),
+            case_blocks: vec![],
+            else_block: vec![],
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::EmptyStatement {
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::ExpressionList {
+            expressions: vec![],
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::ForLoopStatement {
+            body: vec![],
+            by_step: None,
+            counter: Box::new(empty_stmt()),
+            end: Box::new(empty_stmt()),
+            start: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::IfStatement {
+            blocks: vec![],
+            else_block: vec![],
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralArray {
+            elements: None,
+            location: (1..5).into(),
+            id: 7,
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralBool {
+            value: true,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralInteger {
+            value: 7,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralDate {
+            day: 0,
+            month: 0,
+            year: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralDateAndTime {
+            day: 0,
+            month: 0,
+            year: 0,
+            hour: 0,
+            milli: 0,
+            min: 0,
+            sec: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralReal {
+            value: "2.3".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralString {
+            is_wide: false,
+            value: "2.3".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralTime {
+            day: 0.0,
+            hour: 0.0,
+            milli: 0.0,
+            min: 0.0,
+            sec: 0.0,
+            micro: 0.0,
+            nano: 0,
+            negative: false,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::LiteralTimeOfDay {
+            hour: 0,
+            min: 0,
+            sec: 0,
+            milli: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::MultipliedStatement {
+            element: Box::new(empty_stmt()),
+            multiplier: 9,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::OutputAssignment {
+            left: Box::new(empty_stmt()),
+            right: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::QualifiedReference {
+            elements: vec![],
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::RangeStatement {
+            start: Box::new(empty_stmt()),
+            end: Box::new(empty_stmt()),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::Reference {
+            name: "ab".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::RepeatLoopStatement {
+            body: vec![],
+            condition: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::UnaryExpression {
+            operator: Operator::Minus,
+            value: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+    assert_eq!(
+        Statement::WhileLoopStatement {
+            body: vec![],
+            condition: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_id(),
+        7
+    );
+}
+
+fn at(location: Range<usize>) -> Statement {
+    Statement::EmptyStatement {
+        id: 7,
+        location: location.into(),
+    }
+}
+
+#[test]
+fn location_implementation_for_all_statements() {
+    assert_eq!(
+        Statement::ArrayAccess {
+            reference: Box::new(at(0..1)),
+            access: Box::new(at(2..4)),
+            id: 7
+        }
+        .get_location(),
+        (0..4).into()
+    );
+    assert_eq!(
+        Statement::Assignment {
+            left: Box::new(at(0..2)),
+            right: Box::new(at(3..8)),
+            id: 7
+        }
+        .get_location(),
+        (0..8).into()
+    );
+    assert_eq!(
+        Statement::BinaryExpression {
+            left: Box::new(at(0..2)),
+            right: Box::new(at(3..8)),
+            operator: Operator::And,
+            id: 7
+        }
+        .get_location(),
+        (0..8).into()
+    );
+    assert_eq!(
+        Statement::CallStatement {
+            operator: Box::new(empty_stmt()),
+            parameters: Box::new(None),
+            id: 7,
+            location: (1..5).into()
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::CaseCondition {
+            condition: Box::new(at(2..4)),
+            id: 7
+        }
+        .get_location(),
+        (2..4).into()
+    );
+    assert_eq!(
+        Statement::CaseStatement {
+            selector: Box::new(empty_stmt()),
+            case_blocks: vec![],
+            else_block: vec![],
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::EmptyStatement {
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::ExpressionList {
+            expressions: vec![at(0..3), at(4..8)],
+            id: 7
+        }
+        .get_location(),
+        (0..8).into()
+    );
+    assert_eq!(
+        Statement::ForLoopStatement {
+            body: vec![],
+            by_step: None,
+            counter: Box::new(empty_stmt()),
+            end: Box::new(empty_stmt()),
+            start: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::IfStatement {
+            blocks: vec![],
+            else_block: vec![],
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralArray {
+            elements: None,
+            location: (1..5).into(),
+            id: 7,
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralBool {
+            value: true,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralInteger {
+            value: 7,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralDate {
+            day: 0,
+            month: 0,
+            year: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralDateAndTime {
+            day: 0,
+            month: 0,
+            year: 0,
+            hour: 0,
+            milli: 0,
+            min: 0,
+            sec: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralReal {
+            value: "2.3".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralString {
+            is_wide: false,
+            value: "2.3".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralTime {
+            day: 0.0,
+            hour: 0.0,
+            milli: 0.0,
+            min: 0.0,
+            sec: 0.0,
+            micro: 0.0,
+            nano: 0,
+            negative: false,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::LiteralTimeOfDay {
+            hour: 0,
+            min: 0,
+            sec: 0,
+            milli: 0,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::MultipliedStatement {
+            element: Box::new(empty_stmt()),
+            multiplier: 9,
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::OutputAssignment {
+            left: Box::new(at(0..3)),
+            right: Box::new(at(4..9)),
+            id: 7
+        }
+        .get_location(),
+        (0..9).into()
+    );
+    assert_eq!(
+        Statement::QualifiedReference {
+            elements: vec![at(0..3), at(4..5)],
+            id: 7
+        }
+        .get_location(),
+        (0..5).into()
+    );
+    assert_eq!(
+        Statement::RangeStatement {
+            start: Box::new(at(0..3)),
+            end: Box::new(at(6..9)),
+            id: 7
+        }
+        .get_location(),
+        (0..9).into()
+    );
+    assert_eq!(
+        Statement::Reference {
+            name: "ab".to_string(),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::RepeatLoopStatement {
+            body: vec![],
+            condition: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::UnaryExpression {
+            operator: Operator::Minus,
+            value: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
+    assert_eq!(
+        Statement::WhileLoopStatement {
+            body: vec![],
+            condition: Box::new(empty_stmt()),
+            location: (1..5).into(),
+            id: 7
+        }
+        .get_location(),
+        (1..5).into()
+    );
 }

--- a/src/parser/tests/parse_errors/parse_error_containers_tests.rs
+++ b/src/parser/tests/parse_errors/parse_error_containers_tests.rs
@@ -42,7 +42,8 @@ fn missing_pou_name() {
             "{:#?}",
             Statement::Reference {
                 name: "a".into(),
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             }
         )
     );
@@ -81,7 +82,8 @@ fn missing_pou_name_2() {
             "{:#?}",
             Statement::Reference {
                 name: "x".into(),
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             }
         )
     );
@@ -114,7 +116,8 @@ fn illegal_end_pou_keyword() {
             "{:#?}",
             vec![Statement::Reference {
                 name: "b".into(),
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             }]
         )
     );
@@ -208,7 +211,8 @@ fn program_with_illegal_return_variable_declaration() {
             "{:#?}",
             vec![Statement::Reference {
                 name: "a".into(),
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             }]
         )
     );

--- a/src/parser/tests/parse_errors/parse_error_literals_tests.rs
+++ b/src/parser/tests/parse_errors/parse_error_literals_tests.rs
@@ -174,6 +174,7 @@ fn string_with_round_parens_can_be_parsed() {
                     size: Some(LiteralInteger {
                         value: 253,
                         location: (10..11).into(),
+                        id: 0,
                     }),
                     is_wide: false,
                 },
@@ -185,6 +186,7 @@ fn string_with_round_parens_can_be_parsed() {
                     size: Some(LiteralInteger {
                         value: 254,
                         location: (10..11).into(),
+                        id: 0,
                     }),
                     is_wide: false,
                 },
@@ -192,6 +194,7 @@ fn string_with_round_parens_can_be_parsed() {
                     is_wide: false,
                     location: SourceRange::undefined(),
                     value: "abc".into(),
+                    id: 0,
                 }),
             },
             UserTypeDeclaration {
@@ -200,6 +203,7 @@ fn string_with_round_parens_can_be_parsed() {
                     size: Some(LiteralInteger {
                         value: 255,
                         location: (10..11).into(),
+                        id: 0,
                     }),
                     is_wide: false,
                 },

--- a/src/parser/tests/parse_errors/parse_error_statements_tests.rs
+++ b/src/parser/tests/parse_errors/parse_error_statements_tests.rs
@@ -13,7 +13,7 @@ use pretty_assertions::*;
 /*
  * These tests deal with parsing-behavior in the expressions: ()  expressions: ()  presence of errors.
  * following scenarios will be tested:
- *  - missing semicolons at different locations
+ *  - missing semico id: ()  id: () lons at different locations
  *  - incomplete statements
  *  - incomplete statement-blocks (brackets)
  */
@@ -84,8 +84,10 @@ fn missing_comma_in_call_parameters() {
                 location: SourceRange::undefined(),
                 operator: Box::new(ref_to("buz")),
                 parameters: Box::new(Some(Statement::ExpressionList {
-                    expressions: vec![ref_to("a"), ref_to("b"),]
-                }))
+                    expressions: vec![ref_to("a"), ref_to("b"),],
+                    id: 0
+                })),
+                id: 0
             }]
         )
     );
@@ -131,8 +133,10 @@ fn illegal_semicolon_in_call_parameters() {
                     location: SourceRange::undefined(),
                     operator: Box::new(ref_to("buz")),
                     parameters: Box::new(Some(Statement::ExpressionList {
-                        expressions: vec![ref_to("a"), ref_to("b")]
-                    }))
+                        expressions: vec![ref_to("a"), ref_to("b")],
+                        id: 0
+                    })),
+                    id: 0
                 },
                 ref_to("c")
             ]
@@ -431,31 +435,37 @@ fn test_nested_if_with_missing_end_if() {
                 blocks: vec![ConditionalBlock {
                     condition: Box::new(Statement::LiteralBool {
                         value: false,
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     }),
                     body: vec![
                         Statement::IfStatement {
                             blocks: vec![ConditionalBlock {
                                 condition: Box::new(Statement::LiteralBool {
                                     value: true,
-                                    location: SourceRange::undefined()
+                                    location: SourceRange::undefined(),
+                                    id: 0
                                 }),
                                 body: vec![Statement::Assignment {
                                     left: Box::new(ref_to("x")),
-                                    right: Box::new(ref_to("y"))
+                                    right: Box::new(ref_to("y")),
+                                    id: 0
                                 }],
                             }],
                             else_block: vec![],
                             location: SourceRange::undefined(),
+                            id: 0,
                         },
                         Statement::Assignment {
                             left: Box::new(ref_to("y")),
-                            right: Box::new(ref_to("x"))
+                            right: Box::new(ref_to("x")),
+                            id: 0
                         }
                     ]
                 },],
                 else_block: vec![],
                 location: SourceRange::undefined(),
+                id: 0,
             },]
         )
     );
@@ -518,11 +528,13 @@ fn test_nested_for_with_missing_end_for() {
                 counter: Box::new(ref_to("x")),
                 start: Box::new(Statement::LiteralInteger {
                     value: 1,
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 }),
                 end: Box::new(Statement::LiteralInteger {
                     value: 2,
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 }),
                 by_step: None,
                 body: vec![
@@ -530,26 +542,32 @@ fn test_nested_for_with_missing_end_for() {
                         counter: Box::new(ref_to("x")),
                         start: Box::new(Statement::LiteralInteger {
                             value: 1,
-                            location: SourceRange::undefined()
+                            location: SourceRange::undefined(),
+                            id: 0
                         }),
                         end: Box::new(Statement::LiteralInteger {
                             value: 2,
-                            location: SourceRange::undefined()
+                            location: SourceRange::undefined(),
+                            id: 0
                         }),
 
                         by_step: None,
                         body: vec![Statement::Assignment {
                             left: Box::new(ref_to("y")),
-                            right: Box::new(ref_to("x"))
+                            right: Box::new(ref_to("x")),
+                            id: 0
                         },],
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("x")),
-                        right: Box::new(ref_to("y"))
+                        right: Box::new(ref_to("y")),
+                        id: 0
                     }
                 ],
-                location: SourceRange::undefined()
+                location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -589,19 +607,24 @@ fn test_repeat_with_missing_semicolon_in_body() {
                         left: Box::new(ref_to("x")),
                         right: Box::new(Statement::LiteralInteger {
                             value: 3,
-                            location: SourceRange::undefined()
-                        })
+                            location: SourceRange::undefined(),
+                            id: 0
+                        }),
+                        id: 0
                     }],
                     condition: Box::new(Statement::BinaryExpression {
                         left: Box::new(ref_to("x")),
                         right: Box::new(ref_to("y")),
-                        operator: crate::ast::Operator::Equal
+                        operator: crate::ast::Operator::Equal,
+                        id: 0
                     }),
                     location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::Assignment {
                     left: Box::new(ref_to("y")),
-                    right: Box::new(ref_to("x"))
+                    right: Box::new(ref_to("x")),
+                    id: 0
                 }
             ]
         )
@@ -644,17 +667,21 @@ fn test_nested_repeat_with_missing_until_end_repeat() {
                         condition: Box::new(Statement::BinaryExpression {
                             left: Box::new(ref_to("x")),
                             right: Box::new(ref_to("y")),
-                            operator: crate::ast::Operator::Equal
+                            operator: crate::ast::Operator::Equal,
+                            id: 0
                         }),
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("y")),
-                        right: Box::new(ref_to("x"))
+                        right: Box::new(ref_to("x")),
+                        id: 0
                     }
                 ],
                 condition: Box::new(empty_stmt()),
                 location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -701,17 +728,21 @@ fn test_nested_repeat_with_missing_condition_and_end_repeat() {
                         condition: Box::new(Statement::BinaryExpression {
                             left: Box::new(ref_to("x")),
                             right: Box::new(ref_to("y")),
-                            operator: crate::ast::Operator::Equal
+                            operator: crate::ast::Operator::Equal,
+                            id: 0
                         }),
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("y")),
-                        right: Box::new(ref_to("x"))
+                        right: Box::new(ref_to("x")),
+                        id: 0
                     }
                 ],
                 condition: Box::new(empty_stmt()),
                 location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -754,21 +785,26 @@ fn test_nested_repeat_with_missing_end_repeat() {
                         condition: Box::new(Statement::BinaryExpression {
                             left: Box::new(ref_to("x")),
                             right: Box::new(ref_to("y")),
-                            operator: crate::ast::Operator::Equal
+                            operator: crate::ast::Operator::Equal,
+                            id: 0
                         }),
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("y")),
-                        right: Box::new(ref_to("x"))
+                        right: Box::new(ref_to("x")),
+                        id: 0
                     }
                 ],
                 condition: Box::new(Statement::BinaryExpression {
                     left: Box::new(ref_to("x")),
                     right: Box::new(ref_to("y")),
-                    operator: crate::ast::Operator::Equal
+                    operator: crate::ast::Operator::Equal,
+                    id: 0
                 }),
                 location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -808,19 +844,24 @@ fn test_while_with_missing_semicolon_in_body() {
                         left: Box::new(ref_to("x")),
                         right: Box::new(Statement::LiteralInteger {
                             value: 3,
-                            location: SourceRange::undefined()
-                        })
+                            location: SourceRange::undefined(),
+                            id: 0
+                        }),
+                        id: 0
                     }],
                     condition: Box::new(Statement::BinaryExpression {
                         left: Box::new(ref_to("x")),
                         right: Box::new(ref_to("y")),
-                        operator: crate::ast::Operator::Equal
+                        operator: crate::ast::Operator::Equal,
+                        id: 0
                     }),
                     location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::Assignment {
                     left: Box::new(ref_to("y")),
-                    right: Box::new(ref_to("x"))
+                    right: Box::new(ref_to("x")),
+                    id: 0
                 }
             ]
         )
@@ -863,21 +904,26 @@ fn test_nested_while_with_missing_end_while() {
                         condition: Box::new(Statement::BinaryExpression {
                             left: Box::new(ref_to("x")),
                             right: Box::new(ref_to("y")),
-                            operator: crate::ast::Operator::Equal
+                            operator: crate::ast::Operator::Equal,
+                            id: 0
                         }),
-                        location: SourceRange::undefined()
+                        location: SourceRange::undefined(),
+                        id: 0
                     },
                     Statement::Assignment {
                         left: Box::new(ref_to("y")),
-                        right: Box::new(ref_to("x"))
+                        right: Box::new(ref_to("x")),
+                        id: 0
                     }
                 ],
                 condition: Box::new(Statement::BinaryExpression {
                     left: Box::new(ref_to("x")),
                     right: Box::new(ref_to("y")),
-                    operator: crate::ast::Operator::Equal
+                    operator: crate::ast::Operator::Equal,
+                    id: 0
                 }),
                 location: SourceRange::undefined(),
+                id: 0
             },]
         )
     );
@@ -909,14 +955,17 @@ fn test_while_with_missing_do() {
             vec![Statement::WhileLoopStatement {
                 body: vec![Statement::Assignment {
                     left: Box::new(ref_to("y")),
-                    right: Box::new(ref_to("x"))
+                    right: Box::new(ref_to("x")),
+                    id: 0
                 }],
                 condition: Box::new(Statement::BinaryExpression {
                     left: Box::new(ref_to("x")),
                     right: Box::new(ref_to("y")),
-                    operator: crate::ast::Operator::Equal
+                    operator: crate::ast::Operator::Equal,
+                    id: 0
                 }),
                 location: SourceRange::undefined(),
+                id: 0
             }]
         )
     );
@@ -956,10 +1005,12 @@ fn test_case_body_with_missing_semicolon() {
                     body: vec![Statement::Assignment {
                         left: Box::new(ref_to("y")),
                         right: Box::new(ref_to("z")),
+                        id: 0
                     }],
                 },],
                 else_block: vec![],
                 location: SourceRange::undefined(),
+                id: 0
             }]
         )
     );

--- a/src/parser/tests/statement_parser_tests.rs
+++ b/src/parser/tests/statement_parser_tests.rs
@@ -16,16 +16,20 @@ fn empty_statements_are_are_parsed() {
             "{:?}",
             vec![
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
             ]
         ),
@@ -45,20 +49,25 @@ fn empty_statements_are_parsed_before_a_statement() {
             "{:?}",
             vec![
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::EmptyStatement {
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
                 Statement::Reference {
                     name: "x".into(),
-                    location: SourceRange::undefined()
+                    location: SourceRange::undefined(),
+                    id: 0
                 },
             ]
         ),

--- a/src/parser/tests/type_parser_tests.rs
+++ b/src/parser/tests/type_parser_tests.rs
@@ -117,11 +117,14 @@ fn array_type_can_be_parsed_test() {
                     start: Box::new(Statement::LiteralInteger {
                         value: 0,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
                     end: Box::new(Statement::LiteralInteger {
                         value: 8,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
+                    id: 0,
                 },
                 referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
                     referenced_type: "INT".to_string(),
@@ -152,6 +155,7 @@ fn string_type_can_be_parsed_test() {
                     size: Some(LiteralInteger {
                         value: 253,
                         location: (10..11).into(),
+                        id: 0,
                     }),
                     is_wide: false,
                 },
@@ -163,6 +167,7 @@ fn string_type_can_be_parsed_test() {
                     size: Some(LiteralInteger {
                         value: 253,
                         location: (10..11).into(),
+                        id: 0,
                     }),
                     is_wide: false,
                 },
@@ -170,6 +175,7 @@ fn string_type_can_be_parsed_test() {
                     is_wide: false,
                     location: SourceRange::undefined(),
                     value: "abc".into(),
+                    id: 0,
                 }),
             }
         ]
@@ -194,6 +200,7 @@ fn wide_string_type_can_be_parsed_test() {
                 size: Some(LiteralInteger {
                     value: 253,
                     location: (10..11).into(),
+                    id: 0,
                 }),
                 is_wide: true,
             },
@@ -223,11 +230,14 @@ fn subrangetype_can_be_parsed() {
                     start: Box::new(LiteralInteger {
                         value: 0,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
                     end: Box::new(LiteralInteger {
                         value: 1000,
                         location: SourceRange::undefined(),
+                        id: 0,
                     }),
+                    id: 0,
                 }),
                 referenced_type: "UINT".to_string(),
             },

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -313,11 +313,12 @@ impl<'i> TypeAnnotator<'i> {
                 if operator == &Operator::Minus {
                     //keep the same type but switch to signed
                     if let Some(target) = typesystem::get_signed_type(inner_type, self.index) {
-                        self.annotation_map.annotate_type(value, target.get_name());
+                        self.annotation_map
+                            .annotate_type(statement, target.get_name());
                     }
                 } else {
                     self.annotation_map
-                        .annotate_type(value, inner_type.get_name());
+                        .annotate_type(statement, inner_type.get_name());
                 }
             }
             Statement::Reference { name, .. } => {
@@ -374,6 +375,12 @@ impl<'i> TypeAnnotator<'i> {
             }
             Statement::OutputAssignment { left, right, .. } => {
                 visit_all_statements!(self, ctx, left, right);
+                if let Some(lhs) = ctx.call {
+                    //special context for left hand side
+                    self.visit_statement(&ctx.with_pou(lhs), left);
+                } else {
+                    self.visit_statement(ctx, left);
+                }
             }
             Statement::CallStatement {
                 parameters,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -187,7 +187,7 @@ impl<'i> TypeAnnotator<'i> {
                 ..
             } => {
                 self.visit_statement(annotation_map, ctx, elements.as_ref());
-                //TODO
+                //TODO 
             }
             Statement::MultipliedStatement { element, .. } => {
                 self.visit_statement(annotation_map, ctx, element)
@@ -212,7 +212,14 @@ impl<'i> TypeAnnotator<'i> {
                 reference, access, ..
             } => {
                 visit_all_statements!(self, annotation_map, ctx, reference, access);
-                //TODO
+                let array_type = annotation_map.get_type(reference, self.index).get_type_information();
+                if let DataTypeInformation::Array { inner_type_name, ..} = array_type {
+                    let t = self.index.find_type(inner_type_name)
+                        .and_then(|t| self.index.find_effective_type(t))
+                        .map(|t| t.get_name())
+                        .unwrap_or("VOID");
+                    annotation_map.annotate_type(statement, t);
+                }
             }
             Statement::BinaryExpression { left, right, .. } => {
                 visit_all_statements!(self, annotation_map, ctx, left, right);

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -13,50 +13,78 @@ use crate::{
         UserTypeDeclaration, Variable,
     },
     index::Index,
-    typesystem::{self, get_bigger_type_borrow, DataTypeInformation},
+    typesystem::{
+        self, get_bigger_type_borrow, DataTypeInformation, BOOL_TYPE, BYTE_TYPE,
+        DATE_AND_TIME_TYPE, DATE_TYPE, REAL_TYPE, STRING_TYPE, TIME_OF_DAY_TYPE, TIME_TYPE,
+        UDINT_TYPE, UINT_TYPE, ULINT_TYPE,
+    },
 };
 
 #[cfg(test)]
 mod tests;
 
+/// helper macro that calls visit_statement for all given statements
+/// use like `visit_all_statements!(self, ctx, stmt1, stmt2, stmt3, ...)`
+macro_rules! visit_all_statements {
+     ($self:expr, $ctx:expr, $last:expr ) => {
+         $self.visit_statement($ctx, $last);
+     };
+
+     ($self:expr, $ctx:expr, $head:expr, $($tail:expr), +) => {
+       $self.visit_statement($ctx, $head);
+       visit_all_statements!($self, $ctx, $($tail),+)
+     };
+   }
+
+/// Context object passed by the visitor
+/// Denotes the current context of expressions (e.g. the current pou, a defined context, etc.)
+///
+/// Helper methods `qualifier`, `current_pou` and `lhs_pou` copy the current context and
+/// change one field.
 #[derive(Clone)]
-pub struct VisitorContext<'s> {
-    /// context for a reference (e.g. 'CONTEXT' when handling 'x' for 'CONTEXT.x')
-    current_qualifier: Option<&'s str>,
-    /// optional context for references (e.g. 'x' may mean 'CONTEXT.x')
-    current_pou: Option<&'s str>,
-    /// special context of the left-hand-side of an assignment
-    lhs_pou: Option<&'s str>,
+struct VisitorContext<'s> {
+    /// the type_name of the context for a reference (e.g. `a.b` where `a`'s type is the context of `b`)
+    qualifier: Option<&'s str>,
+    /// optional context for references (e.g. `x` may mean `POU.x` if used inside `POU`'s body)
+    pou: Option<&'s str>,
+    /// special context of the left-hand-side of an assignment in call statements
+    /// Inside the left hand side of an assignment is in the context of the call's POU
+    /// `foo(a := a)` actually means: `foo(foo.a := POU.a)`
+    call: Option<&'s str>,
 }
 
 impl<'s> VisitorContext<'s> {
-    pub fn qualifier(&self, qualifier: &'s str) -> VisitorContext<'s> {
+    /// returns a copy of the current context and changes the `current_qualifier` to the given qualifier
+    fn with_qualifier(&self, qualifier: &'s str) -> VisitorContext<'s> {
         VisitorContext {
-            current_pou: self.current_pou,
-            current_qualifier: Some(qualifier),
-            lhs_pou: self.lhs_pou,
+            pou: self.pou,
+            qualifier: Some(qualifier),
+            call: self.call,
         }
     }
 
-    pub fn current_pou(&self, pou: &'s str) -> VisitorContext<'s> {
+    /// returns a copy of the current context and changes the `current_pou` to the given pou
+    fn with_pou(&self, pou: &'s str) -> VisitorContext<'s> {
         VisitorContext {
-            current_pou: Some(pou),
-            current_qualifier: self.current_qualifier,
-            lhs_pou: self.lhs_pou,
+            pou: Some(pou),
+            qualifier: self.qualifier,
+            call: self.call,
         }
     }
 
-    pub fn lhs_pou(&self, lhs_pou: &'s str) -> VisitorContext<'s> {
+    /// returns a copy of the current context and changes the `lhs_pou` to the given pou
+    fn with_call(&self, lhs_pou: &'s str) -> VisitorContext<'s> {
         VisitorContext {
-            current_pou: self.current_pou,
-            current_qualifier: self.current_qualifier,
-            lhs_pou: Some(lhs_pou),
+            pou: self.pou,
+            qualifier: self.qualifier,
+            call: Some(lhs_pou),
         }
     }
 }
 
 pub struct TypeAnnotator<'i> {
     index: &'i Index,
+    annotation_map: AnnotationMap,
     //context: VisitorContext<'i>,
 }
 
@@ -73,11 +101,12 @@ impl AnnotationMap {
         }
     }
 
-    /// annotates the given statement (using it's ID) with the given type-name
+    /// annotates the given statement (using it's `get_id()`) with the given type-name
     pub fn annotate_type(&mut self, s: &Statement, type_name: &str) {
         self.type_map.insert(s.get_id(), type_name.to_string());
     }
 
+    /// returns the annotated type or void if none was annotated
     pub fn get_type<'i>(&self, s: &Statement, index: &'i Index) -> &'i typesystem::DataType {
         self.type_map
             .get(&s.get_id())
@@ -86,300 +115,108 @@ impl AnnotationMap {
     }
 }
 
-macro_rules! visit_all_statements {
-     ($self:expr, $annotation:expr, $ctx:expr, $last:expr ) => {
-         $self.visit_statement($annotation, $ctx, $last);
-     };
-
-     ($self:expr, $annotation:expr, $ctx:expr, $head:expr, $($tail:expr), +) => {
-       $self.visit_statement($annotation, $ctx, $head);
-       visit_all_statements!($self, $annotation, $ctx, $($tail),+)
-     };
-   }
-
 impl<'i> TypeAnnotator<'i> {
     /// constructs a new TypeAnnotater that works with the given index for type-lookups
-    pub fn new(index: &'i Index) -> TypeAnnotator<'i> {
+    fn new(index: &'i Index) -> TypeAnnotator<'i> {
         TypeAnnotator {
-            /*context: VisitorContext {
-                current_pou: None,
-                current_qualifier: None,
-            },*/
+            annotation_map: AnnotationMap::new(),
             index,
         }
     }
 
     /// annotates the given AST elements with the type-name resulting for the statements/expressions.
-    ///
     /// Returns an AnnotationMap with the resulting types for all visited Statements. See `AnnotationMap`
-    pub fn visit_unit(&mut self, unit: &'i CompilationUnit) -> AnnotationMap {
-        let mut annotation_map = AnnotationMap::new();
+    pub fn visit_unit(index: &Index, unit: &'i CompilationUnit) -> AnnotationMap {
+        let mut visitor = TypeAnnotator::new(index);
+
         let ctx = &VisitorContext {
-            current_pou: None,
-            current_qualifier: None,
-            lhs_pou: None,
+            pou: None,
+            qualifier: None,
+            call: None,
         };
 
         for pou in &unit.units {
-            self.visit_pou(&mut annotation_map, ctx, pou);
+            visitor.visit_pou(ctx, pou);
         }
 
         for t in &unit.types {
-            self.visit_user_type_declaration(t, ctx, &mut annotation_map);
+            visitor.visit_user_type_declaration(t, ctx);
         }
 
         for i in &unit.implementations {
-            i.statements.iter().for_each(|s| {
-                self.visit_statement(&mut annotation_map, &ctx.current_pou(i.name.as_str()), s)
-            });
+            i.statements
+                .iter()
+                .for_each(|s| visitor.visit_statement(&ctx.with_pou(i.name.as_str()), s));
         }
-        annotation_map
+        visitor.annotation_map
     }
 
     fn visit_user_type_declaration(
         &mut self,
         user_data_type: &UserTypeDeclaration,
         ctx: &VisitorContext,
-        annotation_map: &mut AnnotationMap,
     ) {
-        self.visit_data_type(ctx, annotation_map, &user_data_type.data_type);
+        self.visit_data_type(ctx, &user_data_type.data_type);
         if let Some(initializer) = &user_data_type.initializer {
-            self.visit_statement(annotation_map, ctx, &initializer);
+            self.visit_statement(ctx, &initializer);
         }
     }
 
-    fn visit_pou(
-        &mut self,
-        annotation_map: &mut AnnotationMap,
-        ctx: &VisitorContext,
-        pou: &'i Pou,
-    ) {
-        let pou_ctx = ctx.current_pou(pou.name.as_str());
+    fn visit_pou(&mut self, ctx: &VisitorContext, pou: &'i Pou) {
+        let pou_ctx = ctx.with_pou(pou.name.as_str());
         for block in &pou.variable_blocks {
             for variable in &block.variables {
-                self.visit_variable(&pou_ctx, annotation_map, variable);
+                self.visit_variable(&pou_ctx, variable);
             }
         }
     }
 
-    fn visit_variable(
-        &mut self,
-        ctx: &VisitorContext,
-        annotation_map: &mut AnnotationMap,
-        variable: &Variable,
-    ) {
-        self.visit_data_type_declaration(ctx, annotation_map, &variable.data_type);
+    fn visit_variable(&mut self, ctx: &VisitorContext, variable: &Variable) {
+        self.visit_data_type_declaration(ctx, &variable.data_type);
     }
 
     fn visit_data_type_declaration(
         &mut self,
         ctx: &VisitorContext,
-        annotation_map: &mut AnnotationMap,
         declaration: &DataTypeDeclaration,
     ) {
         if let DataTypeDeclaration::DataTypeDefinition { data_type } = declaration {
-            self.visit_data_type(ctx, annotation_map, data_type);
+            self.visit_data_type(ctx, data_type);
         }
     }
 
-    fn visit_data_type(
-        &mut self,
-        ctx: &VisitorContext,
-        annotation_map: &mut AnnotationMap,
-        data_type: &DataType,
-    ) {
+    fn visit_data_type(&mut self, ctx: &VisitorContext, data_type: &DataType) {
         match data_type {
-            DataType::StructType { variables, .. } => variables
-                .iter()
-                .for_each(|v| self.visit_variable(ctx, annotation_map, v)),
+            DataType::StructType { variables, .. } => {
+                variables.iter().for_each(|v| self.visit_variable(ctx, v))
+            }
             DataType::ArrayType {
                 referenced_type, ..
-            } => self.visit_data_type_declaration(ctx, annotation_map, referenced_type),
+            } => self.visit_data_type_declaration(ctx, referenced_type),
             DataType::VarArgs {
                 referenced_type: Some(referenced_type),
             } => {
-                self.visit_data_type_declaration(ctx, annotation_map, referenced_type.as_ref());
+                self.visit_data_type_declaration(ctx, referenced_type.as_ref());
             }
             _ => {}
         }
     }
 
-    fn visit_statement(
-        &mut self,
-        annotation_map: &mut AnnotationMap,
-        ctx: &VisitorContext,
-        statement: &Statement,
-    ) {
+    fn visit_statement(&mut self, ctx: &VisitorContext, statement: &Statement) {
+        self.visit_statement_control(ctx, statement);
+    }
+
+    /// annotate a control statement
+    fn visit_statement_control(&mut self, ctx: &VisitorContext, statement: &Statement) {
         match statement {
-            Statement::LiteralBool { .. } => annotation_map.annotate_type(statement, "BOOL"),
-            Statement::LiteralString { .. } => {
-                annotation_map.annotate_type(statement, "STRING");
-            }
-            Statement::LiteralInteger { value, .. } => {
-                annotation_map.annotate_type(statement, get_int_type_name_for(*value));
-            }
-            Statement::LiteralTime { .. } => annotation_map.annotate_type(statement, "TIME"),
-            Statement::LiteralTimeOfDay { .. } => {
-                annotation_map.annotate_type(statement, "TIME_OF_DAY");
-            }
-            Statement::LiteralDate { .. } => {
-                annotation_map.annotate_type(statement, "DATE");
-            }
-            Statement::LiteralDateAndTime { .. } => {
-                annotation_map.annotate_type(statement, "DATE_AND_TIME");
-            }
-            Statement::LiteralReal { .. } => {
-                annotation_map.annotate_type(statement, "REAL");
-            }
-            Statement::LiteralArray {
-                elements: Some(elements),
-                ..
-            } => {
-                self.visit_statement(annotation_map, ctx, elements.as_ref());
-                //TODO
-            }
-            Statement::MultipliedStatement { element, .. } => {
-                self.visit_statement(annotation_map, ctx, element)
-                //TODO
-            }
-            Statement::ArrayAccess {
-                reference, access, ..
-            } => {
-                visit_all_statements!(self, annotation_map, ctx, reference, access);
-                let array_type = annotation_map
-                    .get_type(reference, self.index)
-                    .get_type_information();
-                if let DataTypeInformation::Array {
-                    inner_type_name, ..
-                } = array_type
-                {
-                    let t = self
-                        .index
-                        .find_type(inner_type_name)
-                        .and_then(|t| self.index.find_effective_type(t))
-                        .map(|t| t.get_name())
-                        .unwrap_or("VOID");
-                    annotation_map.annotate_type(statement, t);
-                }
-            }
-            Statement::BinaryExpression { left, right, .. } => {
-                visit_all_statements!(self, annotation_map, ctx, left, right);
-                let left = &annotation_map
-                    .get_type(left, self.index)
-                    .get_type_information();
-                let right = &annotation_map
-                    .get_type(right, self.index)
-                    .get_type_information();
-
-                if left.is_numerical() && right.is_numerical() {
-                    let bigger_name = get_bigger_type_borrow(left, right, self.index).get_name();
-                    annotation_map.annotate_type(statement, bigger_name);
-                }
-            }
-            Statement::UnaryExpression {
-                value, operator, ..
-            } => {
-                self.visit_statement(annotation_map, ctx, value);
-                let inner_type = annotation_map
-                    .get_type(value, self.index)
-                    .get_type_information();
-                if operator == &Operator::Minus {
-                    //keep the same type but switch to signed
-                    if let Some(target) = typesystem::get_signed_type(inner_type, self.index) {
-                        annotation_map.annotate_type(value, target.get_name());
-                    }
-                } else {
-                    annotation_map.annotate_type(value, inner_type.get_name());
-                }
-            }
-            Statement::Reference { name, .. } => {
-                let qualifier = ctx.current_qualifier.or(ctx.current_pou);
-
-                let type_name = qualifier
-                    .and_then(|pou| self.index.find_member(pou, name).map(|v| v.get_type_name()))
-                    .or_else(|| {
-                        let x = self
-                            .index
-                            .find_implementation(name)
-                            .map(|_it| name.as_str() /* this is a pou */);
-                        x
-                    })
-                    .or_else(|| {
-                        self.index
-                            .find_global_variable(name)
-                            .map(|v| v.get_type_name())
-                    });
-
-                let effective_type = type_name
-                    .and_then(|dt| self.index.get_type(dt).ok())
-                    .and_then(|it| self.index.find_effective_type(it));
-
-                if let Some(data_type) = effective_type {
-                    annotation_map.annotate_type(statement, data_type.get_name());
-                }
-            }
-            Statement::QualifiedReference { elements, .. } => {
-                let mut ctx = ctx.clone();
-                for s in elements.iter() {
-                    self.visit_statement(annotation_map, &ctx, s);
-                    ctx = ctx.qualifier(annotation_map.get_type(s, self.index).get_name());
-                }
-
-                //the last guy represents the type of the whole qualified expression
-                if let Some(t) = ctx.current_qualifier {
-                    annotation_map.annotate_type(statement, t);
-                }
-            }
-            Statement::ExpressionList { expressions, .. } => expressions
-                .iter()
-                .for_each(|e| self.visit_statement(annotation_map, ctx, e)),
-            Statement::RangeStatement { start, end, .. } => {
-                visit_all_statements!(self, annotation_map, ctx, start, end);
-            }
-            Statement::Assignment { left, right, .. } => {
-                self.visit_statement(annotation_map, ctx, right);
-                if let Some(lhs) = ctx.lhs_pou {
-                    //special context for left hand side
-                    self.visit_statement(annotation_map, &ctx.current_pou(lhs), left);
-                } else {
-                    self.visit_statement(annotation_map, ctx, left);
-                }
-            }
-            Statement::OutputAssignment { left, right, .. } => {
-                visit_all_statements!(self, annotation_map, ctx, left, right);
-            }
-            Statement::CallStatement {
-                parameters,
-                operator,
-                ..
-            } => {
-                self.visit_statement(annotation_map, ctx, operator);
-                let operator_type_name = annotation_map.get_type(operator, self.index).get_name();
-                if let Some(s) = parameters.as_ref() {
-                    let ctx = ctx.lhs_pou(operator_type_name);
-                    self.visit_statement(annotation_map, &ctx, s);
-                }
-
-                if let Some(return_type) = self
-                    .index
-                    .find_return_type(operator_type_name)
-                    .and_then(|it| self.index.find_effective_type(it))
-                {
-                    annotation_map.annotate_type(statement, return_type.get_name());
-                }
-            }
             Statement::IfStatement {
                 blocks, else_block, ..
             } => {
                 blocks.iter().for_each(|b| {
-                    self.visit_statement(annotation_map, ctx, b.condition.as_ref());
-                    b.body
-                        .iter()
-                        .for_each(|s| self.visit_statement(annotation_map, ctx, s));
+                    self.visit_statement(ctx, b.condition.as_ref());
+                    b.body.iter().for_each(|s| self.visit_statement(ctx, s));
                 });
-                else_block
-                    .iter()
-                    .for_each(|e| self.visit_statement(annotation_map, ctx, e));
+                else_block.iter().for_each(|e| self.visit_statement(ctx, e));
             }
             Statement::ForLoopStatement {
                 counter,
@@ -389,26 +226,23 @@ impl<'i> TypeAnnotator<'i> {
                 body,
                 ..
             } => {
-                visit_all_statements!(self, annotation_map, ctx, counter, start, end);
+                visit_all_statements!(self, ctx, counter, start, end);
                 if let Some(by_step) = by_step {
-                    self.visit_statement(annotation_map, ctx, by_step);
+                    self.visit_statement(ctx, by_step);
                 }
-                body.iter()
-                    .for_each(|s| self.visit_statement(annotation_map, ctx, s));
+                body.iter().for_each(|s| self.visit_statement(ctx, s));
             }
             Statement::WhileLoopStatement {
                 condition, body, ..
             } => {
-                self.visit_statement(annotation_map, ctx, condition);
-                body.iter()
-                    .for_each(|s| self.visit_statement(annotation_map, ctx, s));
+                self.visit_statement(ctx, condition);
+                body.iter().for_each(|s| self.visit_statement(ctx, s));
             }
             Statement::RepeatLoopStatement {
                 condition, body, ..
             } => {
-                self.visit_statement(annotation_map, ctx, condition);
-                body.iter()
-                    .for_each(|s| self.visit_statement(annotation_map, ctx, s));
+                self.visit_statement(ctx, condition);
+                body.iter().for_each(|s| self.visit_statement(ctx, s));
             }
             Statement::CaseStatement {
                 selector,
@@ -416,19 +250,202 @@ impl<'i> TypeAnnotator<'i> {
                 else_block,
                 ..
             } => {
-                self.visit_statement(annotation_map, ctx, selector);
+                self.visit_statement(ctx, selector);
                 case_blocks.iter().for_each(|b| {
-                    self.visit_statement(annotation_map, ctx, b.condition.as_ref());
-                    b.body
-                        .iter()
-                        .for_each(|s| self.visit_statement(annotation_map, ctx, s));
+                    self.visit_statement(ctx, b.condition.as_ref());
+                    b.body.iter().for_each(|s| self.visit_statement(ctx, s));
                 });
-                else_block
-                    .iter()
-                    .for_each(|s| self.visit_statement(annotation_map, ctx, s));
+                else_block.iter().for_each(|s| self.visit_statement(ctx, s));
             }
-            Statement::CaseCondition { condition, .. } => {
-                self.visit_statement(annotation_map, ctx, condition)
+            Statement::CaseCondition { condition, .. } => self.visit_statement(ctx, condition),
+            _ => {
+                self.visit_statement_expression(ctx, statement);
+            }
+        }
+    }
+
+    /// annotate an expression statement
+    fn visit_statement_expression(&mut self, ctx: &VisitorContext, statement: &Statement) {
+        match statement {
+            Statement::ArrayAccess {
+                reference, access, ..
+            } => {
+                visit_all_statements!(self, ctx, reference, access);
+                let array_type = self
+                    .annotation_map
+                    .get_type(reference, self.index)
+                    .get_type_information();
+                if let DataTypeInformation::Array {
+                    inner_type_name, ..
+                } = array_type
+                {
+                    let t = self
+                        .index
+                        .get_effective_type_by_name(inner_type_name)
+                        .get_name();
+                    self.annotation_map.annotate_type(statement, t);
+                }
+            }
+            Statement::BinaryExpression { left, right, .. } => {
+                visit_all_statements!(self, ctx, left, right);
+                let left = &self
+                    .annotation_map
+                    .get_type(left, self.index)
+                    .get_type_information();
+                let right = &self
+                    .annotation_map
+                    .get_type(right, self.index)
+                    .get_type_information();
+
+                if left.is_numerical() && right.is_numerical() {
+                    let bigger_name = get_bigger_type_borrow(left, right, self.index).get_name();
+                    self.annotation_map.annotate_type(statement, bigger_name);
+                }
+            }
+            Statement::UnaryExpression {
+                value, operator, ..
+            } => {
+                self.visit_statement(ctx, value);
+                let inner_type = self
+                    .annotation_map
+                    .get_type(value, self.index)
+                    .get_type_information();
+                if operator == &Operator::Minus {
+                    //keep the same type but switch to signed
+                    if let Some(target) = typesystem::get_signed_type(inner_type, self.index) {
+                        self.annotation_map.annotate_type(value, target.get_name());
+                    }
+                } else {
+                    self.annotation_map
+                        .annotate_type(value, inner_type.get_name());
+                }
+            }
+            Statement::Reference { name, .. } => {
+                let qualifier = ctx.qualifier.or(ctx.pou);
+
+                let type_name = qualifier
+                    .and_then(|pou| self.index.find_member(pou, name).map(|v| v.get_type_name()))
+                    .or_else(|| {
+                        self.index
+                            .find_implementation(name)
+                            .map(|_it| name.as_str() /* this is a pou */)
+                    })
+                    .or_else(|| {
+                        self.index
+                            .find_global_variable(name)
+                            .map(|v| v.get_type_name())
+                    });
+
+                let effective_type =
+                    type_name.map(|name| self.index.get_effective_type_by_name(name));
+
+                if let Some(data_type) = effective_type {
+                    self.annotation_map
+                        .annotate_type(statement, data_type.get_name());
+                }
+            }
+            Statement::QualifiedReference { elements, .. } => {
+                let mut ctx = ctx.clone();
+                for s in elements.iter() {
+                    self.visit_statement(&ctx, s);
+                    ctx =
+                        ctx.with_qualifier(self.annotation_map.get_type(s, self.index).get_name());
+                }
+
+                //the last guy represents the type of the whole qualified expression
+                if let Some(t) = ctx.qualifier {
+                    self.annotation_map.annotate_type(statement, t);
+                }
+            }
+            Statement::ExpressionList { expressions, .. } => expressions
+                .iter()
+                .for_each(|e| self.visit_statement(ctx, e)),
+            Statement::RangeStatement { start, end, .. } => {
+                visit_all_statements!(self, ctx, start, end);
+            }
+            Statement::Assignment { left, right, .. } => {
+                self.visit_statement(ctx, right);
+                if let Some(lhs) = ctx.call {
+                    //special context for left hand side
+                    self.visit_statement(&ctx.with_pou(lhs), left);
+                } else {
+                    self.visit_statement(ctx, left);
+                }
+            }
+            Statement::OutputAssignment { left, right, .. } => {
+                visit_all_statements!(self, ctx, left, right);
+            }
+            Statement::CallStatement {
+                parameters,
+                operator,
+                ..
+            } => {
+                self.visit_statement(ctx, operator);
+                let operator_type_name = self
+                    .annotation_map
+                    .get_type(operator, self.index)
+                    .get_name();
+                if let Some(s) = parameters.as_ref() {
+                    let ctx = ctx.with_call(operator_type_name);
+                    self.visit_statement(&ctx, s);
+                }
+
+                if let Some(return_type) = self
+                    .index
+                    .find_return_type(operator_type_name)
+                    .and_then(|it| self.index.find_effective_type(it))
+                {
+                    self.annotation_map
+                        .annotate_type(statement, return_type.get_name());
+                }
+            }
+            _ => {
+                self.visit_statement_literals(ctx, statement);
+            }
+        }
+    }
+
+    /// annotate a literal statement
+    fn visit_statement_literals(&mut self, ctx: &VisitorContext, statement: &Statement) {
+        match statement {
+            Statement::LiteralBool { .. } => {
+                self.annotation_map.annotate_type(statement, BOOL_TYPE)
+            }
+            Statement::LiteralString { .. } => {
+                self.annotation_map.annotate_type(statement, STRING_TYPE);
+            }
+            Statement::LiteralInteger { value, .. } => {
+                self.annotation_map
+                    .annotate_type(statement, get_int_type_name_for(*value));
+            }
+            Statement::LiteralTime { .. } => {
+                self.annotation_map.annotate_type(statement, TIME_TYPE)
+            }
+            Statement::LiteralTimeOfDay { .. } => {
+                self.annotation_map
+                    .annotate_type(statement, TIME_OF_DAY_TYPE);
+            }
+            Statement::LiteralDate { .. } => {
+                self.annotation_map.annotate_type(statement, DATE_TYPE);
+            }
+            Statement::LiteralDateAndTime { .. } => {
+                self.annotation_map
+                    .annotate_type(statement, DATE_AND_TIME_TYPE);
+            }
+            Statement::LiteralReal { .. } => {
+                //TODO when do we need a LREAL literal?
+                self.annotation_map.annotate_type(statement, REAL_TYPE);
+            }
+            Statement::LiteralArray {
+                elements: Some(elements),
+                ..
+            } => {
+                self.visit_statement(ctx, elements.as_ref());
+                //TODO as of yet we have no way to derive a name that reflects a fixed size array
+            }
+            Statement::MultipliedStatement { element, .. } => {
+                self.visit_statement(ctx, element)
+                //TODO as of yet we have no way to derive a name that reflects a fixed size array
             }
             _ => {}
         }
@@ -438,13 +455,13 @@ impl<'i> TypeAnnotator<'i> {
 fn get_int_type_name_for(value: i64) -> &'static str {
     //TODO how will this ever be a negative number?
     if value <= u8::MAX.into() {
-        "BYTE"
+        BYTE_TYPE
     } else if value <= u16::MAX.into() {
-        "UINT"
+        UINT_TYPE
     } else if value <= u32::MAX.into() {
-        "UDINT"
+        UDINT_TYPE
     } else {
-        "ULINT"
+        ULINT_TYPE
     }
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,327 @@
+// Copyright (c) 2021 Ghaith Hachem and Mathias Rieder
+
+//! Resolves (partial) expressions & statements and annotates the resulting types
+//!
+//! Recursively visits all statements and expressions of a `CompilationUnit` and 
+//! records all resulting types associated with the statement's id.
+
+use indexmap::IndexMap;
+
+use crate::{ast::{
+        AstId, CompilationUnit, DataType, DataTypeDeclaration, Pou, Statement, UserTypeDeclaration,
+        Variable,
+    }, index::Index, typesystem::DataTypeInformation};
+
+#[cfg(test)]
+mod tests;
+
+pub struct VisitorContext<'s> {
+    current_qualifier: Option<&'s str>,
+    current_pou: Option<&'s str>,
+}
+pub struct TypeAnnotator<'i, 's> {
+    index: &'i Index,
+    context: VisitorContext<'s>,
+}
+
+pub struct AnnotationMap {
+    //TODO try to only borrow names?
+    type_map: IndexMap<AstId, String>, // Statement -> type-name
+}
+
+impl AnnotationMap {
+    /// creates a new empty AnnotationMap
+    pub fn new() -> AnnotationMap {
+        AnnotationMap {
+            type_map: IndexMap::new(),
+        }
+    }
+
+    /// annotates the given statement (using it's ID) with the given type-name
+    pub fn annotate_type(&mut self, s: &Statement, type_name: &str) {
+        self.type_map.insert(s.get_id(), type_name.to_string());
+    }
+
+    pub fn get_type<'i> (&self, s: &Statement, index: &'i Index) -> &'i DataTypeInformation{
+        self.type_map.get(&s.get_id())
+            .and_then(|name| index.get_type(name).ok())
+            .map(|data_type| data_type.get_type_information())
+            .unwrap_or_else(|| index.get_void_type().get_type_information())
+    }
+}
+
+macro_rules! visit_all_statements {
+     ($self:expr, $annotation:expr, $last:expr ) => {
+         $self.visit_statement($annotation, $last);
+     };
+
+     ($self:expr, $annotation:expr, $head:expr, $($tail:expr), +) => {
+       $self.visit_statement($annotation, $head);
+       visit_all_statements!($self, $annotation, $($tail),+)
+     };
+   }
+
+impl<'i, 's> TypeAnnotator<'i, 's> {
+    /// constructs a new TypeAnnotater that works with the given index for type-lookups
+    pub fn new(index: &'i Index) -> TypeAnnotator<'i, 's> {
+        TypeAnnotator {
+            context: VisitorContext {
+                current_pou: None,
+                current_qualifier: None,
+            },
+            index,
+        }
+    }
+
+    /// annotates the given AST elements with the type-name resulting for the statements/expressions.
+    /// 
+    /// Returns an AnnotationMap with the resulting types for all visited Statements. See `AnnotationMap`
+    pub fn visit_unit(&mut self, unit: &'s CompilationUnit) -> AnnotationMap {
+        let mut annotation_map = AnnotationMap::new();
+
+        for pou in &unit.units {
+            self.visit_pou(pou, &mut annotation_map);
+        }
+
+        for t in &unit.types {
+            self.visit_user_type_declaration(t, &mut annotation_map);
+        }
+
+        for i in &unit.implementations {
+            let old = std::mem::replace(&mut self.context.current_pou, Some(i.name.as_str()));
+            i.statements
+                .iter()
+                .for_each(|s| self.visit_statement(&mut annotation_map, s));
+            self.context.current_qualifier = old;
+        }
+        annotation_map
+    }
+
+    fn visit_user_type_declaration(&mut self, user_data_type: &UserTypeDeclaration, annotation_map: &mut AnnotationMap) {
+        self.visit_data_type(&user_data_type.data_type, annotation_map);
+        if let Some(initializer) = &user_data_type.initializer {
+            self.visit_statement(annotation_map, &initializer);
+        }
+    }
+
+    fn visit_pou(&mut self, pou: &'s Pou, annotation_map: &mut AnnotationMap) {
+        let old = std::mem::replace(&mut self.context.current_pou, Some(pou.name.as_str()));
+        for block in &pou.variable_blocks {
+            for variable in &block.variables {
+                self.visit_variable(variable, annotation_map);
+            }
+        }
+        self.context.current_pou = old;
+    }
+
+    fn visit_variable(&mut self, variable: &Variable, annotation_map: &mut AnnotationMap) {
+        self.visit_data_type_declaration(&variable.data_type, annotation_map);
+    }
+
+    fn visit_data_type_declaration(
+        &mut self,
+        declaration: &DataTypeDeclaration,
+        annotation_map: &mut AnnotationMap,
+    ) {
+        if let DataTypeDeclaration::DataTypeDefinition { data_type } = declaration {
+            self.visit_data_type(data_type, annotation_map);
+        }
+    }
+
+    fn visit_data_type(&mut self, data_type: &DataType, annotation_map: &mut AnnotationMap) {
+        match data_type {
+            DataType::StructType { variables, .. } => variables
+                .iter()
+                .for_each(|v| self.visit_variable(v, annotation_map)),
+            DataType::ArrayType {
+                referenced_type, ..
+            } => self.visit_data_type_declaration(referenced_type, annotation_map),
+            DataType::VarArgs {
+                referenced_type: Some(referenced_type),
+            } => {
+                self.visit_data_type_declaration(referenced_type.as_ref(), annotation_map);
+            }
+            _ => {}
+        }
+    }
+
+    fn visit_statement(&mut self, annotation_map: &mut AnnotationMap, statement: &Statement) {
+        match statement {
+            Statement::LiteralBool { .. } => annotation_map.annotate_type(statement, "BOOL"),
+            Statement::LiteralString { .. } => {
+                annotation_map.annotate_type(statement, "STRING");
+            }
+            Statement::LiteralInteger { value, .. } => {
+                annotation_map.annotate_type(statement, get_int_type_name_for(*value));
+            }
+            Statement::LiteralTime { .. } => annotation_map.annotate_type(statement, "TIME"),
+            Statement::LiteralTimeOfDay { .. } => {
+                annotation_map.annotate_type(statement, "TIME_OF_DAY");
+            }
+            Statement::LiteralDate{..} => {
+                annotation_map.annotate_type(statement, "DATE");
+            }
+            Statement::LiteralDateAndTime{..} => {
+                annotation_map.annotate_type(statement, "DATE_AND_TIME");
+            }
+            Statement::LiteralReal{..} => {
+                annotation_map.annotate_type(statement, "REAL");
+            }
+            Statement::LiteralArray {
+                elements: Some(elements),
+                ..
+            } => {
+                self.visit_statement(annotation_map, elements.as_ref());   
+                //TODO
+            }
+            Statement::MultipliedStatement { element, .. } => {
+                self.visit_statement(annotation_map, element)
+                //TODO
+            }
+            Statement::QualifiedReference { elements, .. } => {elements
+                .iter()
+                .for_each(|e| self.visit_statement(annotation_map, e));
+                //TODO
+            }
+            Statement::ArrayAccess {
+                reference, access, ..
+            } => {
+                visit_all_statements!(self, annotation_map, reference, access);
+                //TODO
+            }
+            Statement::BinaryExpression { left, right, .. } => {
+                visit_all_statements!(self, annotation_map, left, right);
+                let left_type = annotation_map.get_type(left, self.index);
+                let right_type = annotation_map.get_type(right, self.index);
+
+                let name = if left_type.get_size() > right_type.get_size() {
+                    left_type.get_name()
+                } else {
+                    right_type.get_name()
+                };
+                annotation_map.annotate_type(statement, name);
+
+            }
+            Statement::UnaryExpression { value, .. } => {
+                self.visit_statement(annotation_map, value);
+            }
+            Statement::ExpressionList { expressions, .. } => expressions
+                .iter()
+                .for_each(|e| self.visit_statement(annotation_map, e)),
+            Statement::RangeStatement { start, end, .. } => {
+                visit_all_statements!(self, annotation_map, start, end);
+            }
+            Statement::Assignment { left, right, .. } => {
+                self.visit_statement(annotation_map, left);
+                self.visit_statement(annotation_map, right);
+            }
+            Statement::OutputAssignment { left, right, .. } => {
+                self.visit_statement(annotation_map, left);
+                self.visit_statement(annotation_map, right);
+            }
+            Statement::CallStatement {
+                parameters,
+                operator,
+                ..
+            } => {
+                self.visit_statement(annotation_map, operator);
+                if let Some(s) = parameters.as_ref() {
+                    self.visit_statement(annotation_map, s);
+                }
+            }
+            Statement::IfStatement {
+                blocks, else_block, ..
+            } => {
+                blocks.iter().for_each(|b| {
+                    self.visit_statement(annotation_map, b.condition.as_ref());
+                    b.body
+                        .iter()
+                        .for_each(|s| self.visit_statement(annotation_map, s));
+                });
+                else_block
+                    .iter()
+                    .for_each(|e| self.visit_statement(annotation_map, e));
+            }
+            Statement::ForLoopStatement {
+                counter,
+                start,
+                end,
+                by_step,
+                body,
+                ..
+            } => {
+                visit_all_statements!(self, annotation_map, counter, start, end);
+                if let Some(by_step) = by_step {
+                    self.visit_statement(annotation_map, by_step);
+                }
+                body.iter()
+                    .for_each(|s| self.visit_statement(annotation_map, s));
+            }
+            Statement::WhileLoopStatement {
+                condition, body, ..
+            } => {
+                self.visit_statement(annotation_map, condition);
+                body.iter()
+                    .for_each(|s| self.visit_statement(annotation_map, s));
+            }
+            Statement::RepeatLoopStatement {
+                condition, body, ..
+            } => {
+                self.visit_statement(annotation_map, condition);
+                body.iter()
+                    .for_each(|s| self.visit_statement(annotation_map, s));
+            }
+            Statement::CaseStatement {
+                selector,
+                case_blocks,
+                else_block,
+                ..
+            } => {
+                self.visit_statement(annotation_map, selector);
+                case_blocks.iter().for_each(|b| {
+                    self.visit_statement(annotation_map, b.condition.as_ref());
+                    b.body
+                        .iter()
+                        .for_each(|s| self.visit_statement(annotation_map, s));
+                });
+                else_block
+                    .iter()
+                    .for_each(|s| self.visit_statement(annotation_map, s));
+            }
+            Statement::CaseCondition { condition, .. } => {
+                self.visit_statement(annotation_map, condition)
+            }
+            _ => {}
+        }
+    }
+}
+
+fn get_int_type_name_for(value: i64) -> &'static str {
+    //TODO how will this ever be a negative number?
+    if value <= u8::MAX.into() {
+        "BYTE"
+    } else if value <= u16::MAX.into() {
+        "UINT"
+    } else if value <= u32::MAX.into() {
+        "UDINT"
+    } else {
+        "ULINT"
+    }
+}
+
+#[cfg(test)]
+mod resolver_tests {
+    use super::get_int_type_name_for;
+
+    #[test]
+    fn correct_int_types_name_for_numbers() {
+        assert_eq!(get_int_type_name_for(0), "BYTE");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 8) - 1), "BYTE");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 8)), "UINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 16) - 1), "UINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 16)), "UDINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 32) - 1), "UDINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 32)), "ULINT");
+        assert_eq!(get_int_type_name_for(i64::MAX), "ULINT");
+    }
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -14,9 +14,8 @@ use crate::{
     },
     index::Index,
     typesystem::{
-        self, get_bigger_type_borrow, DataTypeInformation, BOOL_TYPE, BYTE_TYPE,
-        DATE_AND_TIME_TYPE, DATE_TYPE, REAL_TYPE, STRING_TYPE, TIME_OF_DAY_TYPE, TIME_TYPE,
-        UDINT_TYPE, UINT_TYPE, ULINT_TYPE,
+        self, get_bigger_type_borrow, DataTypeInformation, BOOL_TYPE, DATE_AND_TIME_TYPE,
+        DATE_TYPE, DINT_TYPE, LINT_TYPE, REAL_TYPE, STRING_TYPE, TIME_OF_DAY_TYPE, TIME_TYPE,
     },
 };
 
@@ -460,15 +459,10 @@ impl<'i> TypeAnnotator<'i> {
 }
 
 fn get_int_type_name_for(value: i64) -> &'static str {
-    //TODO how will this ever be a negative number?
-    if value <= u8::MAX.into() {
-        BYTE_TYPE
-    } else if value <= u16::MAX.into() {
-        UINT_TYPE
-    } else if value <= u32::MAX.into() {
-        UDINT_TYPE
+    if i32::MIN as i64 <= value && i32::MAX as i64 >= value {
+        DINT_TYPE
     } else {
-        ULINT_TYPE
+        LINT_TYPE
     }
 }
 
@@ -478,13 +472,14 @@ mod resolver_tests {
 
     #[test]
     fn correct_int_types_name_for_numbers() {
-        assert_eq!(get_int_type_name_for(0), "BYTE");
-        assert_eq!(get_int_type_name_for(i64::pow(2, 8) - 1), "BYTE");
-        assert_eq!(get_int_type_name_for(i64::pow(2, 8)), "UINT");
-        assert_eq!(get_int_type_name_for(i64::pow(2, 16) - 1), "UINT");
-        assert_eq!(get_int_type_name_for(i64::pow(2, 16)), "UDINT");
-        assert_eq!(get_int_type_name_for(i64::pow(2, 32) - 1), "UDINT");
-        assert_eq!(get_int_type_name_for(i64::pow(2, 32)), "ULINT");
-        assert_eq!(get_int_type_name_for(i64::MAX), "ULINT");
+        assert_eq!(get_int_type_name_for(0), "DINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 8) - 1), "DINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 8)), "DINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 16) - 1), "DINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 16)), "DINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 31) - 1), "DINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 31)), "LINT");
+        assert_eq!(get_int_type_name_for(i64::pow(2, 32)), "LINT");
+        assert_eq!(get_int_type_name_for(i64::MAX), "LINT");
     }
 }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1,15 +1,18 @@
-use crate::{ast::{self, CompilationUnit}, index::{self, Index}, lexer::lex};
+use crate::{
+    ast::{self, CompilationUnit},
+    index::{self, Index},
+    lexer::lex,
+};
 
 use super::{AnnotationMap, TypeAnnotator};
 
-
+mod resolve_expressions_tests;
 #[cfg(test)]
 mod resolve_literals_tests;
-mod resolve_expressions_tests;
-
 
 fn parse(src: &str) -> (CompilationUnit, Index) {
-    let mut unit = crate::parser::parse(lex(src)).0;
+    let (mut unit, _) = crate::parser::parse(lex(src));
+
     ast::pre_process(&mut unit);
     let index = index::visitor::visit(&unit);
     (unit, index)

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -9,7 +9,7 @@ mod resolve_expressions_tests;
 
 
 fn parse(src: &str) -> (CompilationUnit, Index) {
-    let mut unit = crate::parser::parse(lex(src)).unwrap().0;
+    let mut unit = crate::parser::parse(lex(src)).0;
     ast::pre_process(&mut unit);
     let index = index::visitor::visit(&unit);
     (unit, index)

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -18,7 +18,6 @@ fn parse(src: &str) -> (CompilationUnit, Index) {
     (unit, index)
 }
 
-fn annotate(parse_result: &CompilationUnit, index: Index) -> AnnotationMap {
-    let mut annotator = TypeAnnotator::new(&index);
-    annotator.visit_unit(parse_result)
+fn annotate(parse_result: &CompilationUnit, index: &Index) -> AnnotationMap {
+    TypeAnnotator::visit_unit(index, parse_result)
 }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1,0 +1,21 @@
+use crate::{ast::{self, CompilationUnit}, index::{self, Index}, lexer::lex};
+
+use super::{AnnotationMap, TypeAnnotator};
+
+
+#[cfg(test)]
+mod resolve_literals_tests;
+mod resolve_expressions_tests;
+
+
+fn parse(src: &str) -> (CompilationUnit, Index) {
+    let mut unit = crate::parser::parse(lex(src)).unwrap().0;
+    ast::pre_process(&mut unit);
+    let index = index::visitor::visit(&unit);
+    (unit, index)
+}
+
+fn annotate(parse_result: &CompilationUnit, index: Index) -> AnnotationMap {
+    let mut annotator = TypeAnnotator::new(&index);
+    annotator.visit_unit(parse_result)
+}

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -17,7 +17,7 @@ fn binary_expressions_resolves_types() {
             2000 + 1;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec!["BYTE", "UINT", "UINT"];
@@ -40,7 +40,7 @@ fn binary_expressions_resolves_types_with_floats() {
             2000.0 + 1.0;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec!["REAL", "REAL", "REAL"];
@@ -87,7 +87,7 @@ fn local_variables_resolves_types() {
             uli;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
@@ -137,7 +137,7 @@ fn global_resolves_types() {
             uli;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
@@ -187,7 +187,7 @@ fn resolve_binary_expressions() {
             b + uli;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
@@ -228,7 +228,7 @@ fn complex_expressions_resolve_types() {
             b + w * di + r;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec!["LINT", "DINT", "REAL"];
@@ -271,7 +271,7 @@ fn array_expressions_resolve_types() {
 
         ",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
@@ -316,7 +316,7 @@ fn qualified_expressions_resolve_types() {
             Other.b + Other.w + Other.dw + Other.lw;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[1].statements;
 
     let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "WORD", "DWORD", "LWORD"];
@@ -348,7 +348,7 @@ fn pou_expressions_resolve_types() {
             OtherFuncBlock;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[3].statements;
 
     let expected_types = vec!["OtherPrg", "OtherFunc", "OtherFuncBlock"];
@@ -376,7 +376,7 @@ fn assignment_expressions_resolve_types() {
             z := x;
         END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let nothing = "-".to_string();
@@ -452,7 +452,7 @@ fn qualified_expressions_to_structs_resolve_types() {
         END_PROGRAM",
     );
 
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
@@ -497,7 +497,7 @@ fn qualified_expressions_to_inlined_structs_resolve_types() {
         END_PROGRAM",
     );
 
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec!["__PRG_mys", "BYTE", "WORD", "DWORD", "LWORD"];
@@ -551,7 +551,7 @@ fn qualified_expressions_to_aliased_structs_resolve_types() {
         END_PROGRAM",
     );
 
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
@@ -594,7 +594,7 @@ fn function_parameter_assignments_resolve_types() {
         ",
     );
 
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[1].statements;
 
     assert_eq!(
@@ -658,7 +658,7 @@ fn nested_function_parameter_assignments_resolve_types() {
         END_PROGRAM",
     );
 
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[2].statements;
     if let Statement::CallStatement { parameters, .. } = &statements[0] {
         //check the two parameters

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -582,12 +582,14 @@ fn function_parameter_assignments_resolve_types() {
         FUNCTION foo : MyType
             VAR_INPUT
                 x : INT;
-                y : INT;
+            END_VAR
+            VAR_OUTPUT
+                y : SINT;
             END_VAR
         END_FUNCTION
 
         PROGRAM PRG
-            foo(x := 3, y := 6);
+            foo(x := 3, y => 6);
         END_PROGRAM
         
         TYPE MyType: INT; END_TYPE
@@ -617,6 +619,18 @@ fn function_parameter_assignments_resolve_types() {
                 assert_eq!(
                     annotations.type_map.get(&left.get_id()),
                     Some(&"INT".to_string())
+                );
+                assert_eq!(
+                    annotations.type_map.get(&right.get_id()),
+                    Some(&"BYTE".to_string())
+                );
+            } else {
+                panic!("assignment expected")
+            }
+            if let Statement::OutputAssignment { left, right, .. } = &expressions[1] {
+                assert_eq!(
+                    annotations.type_map.get(&left.get_id()),
+                    Some(&"SINT".to_string())
                 );
                 assert_eq!(
                     annotations.type_map.get(&right.get_id()),

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -14,21 +14,21 @@ fn binary_expressions_resolves_types() {
         "PROGRAM PRG
             1 + 2;
             1 + 2000;
-            2000 + 1;
+            2147483648 + 1;
         END_PROGRAM",
     );
     let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
-    let expected_types = vec!["BYTE", "UINT", "UINT"];
-    for (i, s) in statements.iter().enumerate() {
-        assert_eq!(
-            Some(&expected_types[i].to_string()),
-            annotations.type_map.get(&s.get_id()),
-            "{:#?}",
-            s
-        );
-    }
+    let expected_types = vec!["DINT", "DINT", "LINT"];
+
+    let none = "-".to_string();
+    let types: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&none))
+        .collect();
+
+    assert_eq!(expected_types, types);
 }
 
 #[test]
@@ -622,7 +622,7 @@ fn function_parameter_assignments_resolve_types() {
                 );
                 assert_eq!(
                     annotations.type_map.get(&right.get_id()),
-                    Some(&"BYTE".to_string())
+                    Some(&"DINT".to_string())
                 );
             } else {
                 panic!("assignment expected")
@@ -634,7 +634,7 @@ fn function_parameter_assignments_resolve_types() {
                 );
                 assert_eq!(
                     annotations.type_map.get(&right.get_id()),
-                    Some(&"BYTE".to_string())
+                    Some(&"DINT".to_string())
                 );
             } else {
                 panic!("assignment expected")
@@ -683,7 +683,7 @@ fn nested_function_parameter_assignments_resolve_types() {
         if let Statement::Assignment { right, .. } = get_expression_from_list(parameters, 0) {
             if let Statement::CallStatement { parameters, .. } = right.as_ref() {
                 // the left side here should be `x` - so lets see if it got mixed up with the outer call's `x`
-                assert_parameter_assignment(parameters, 0, "DINT", "BYTE", &annotations);
+                assert_parameter_assignment(parameters, 0, "DINT", "DINT", &annotations);
             } else {
                 panic!("inner call")
             }
@@ -718,7 +718,7 @@ fn assert_parameter_assignment(
             );
             assert_eq!(
                 annotations.type_map.get(&right.get_id()),
-                Some(&right_type.to_string())
+                Some(&right_type.to_string()),
             );
         } else {
             panic!("assignment expected")

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -46,3 +46,251 @@ fn binary_expressions_resolves_types_with_floats() {
         );
     }
 }
+
+
+
+#[test]
+fn local_variables_resolves_types() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+            VAR
+                b : BYTE;
+                w : WORD;
+                dw : DWORD;
+                lw : LWORD;
+                si : SINT;
+                usi : USINT;
+                i : INT;
+                ui : UINT;
+                di : DINT;
+                udi : UDINT;
+                li : LINT;
+                uli : ULINT;
+            END_VAR
+
+            b;
+            w;
+            dw;
+            lw;
+            si;
+            usi;
+            i;
+            ui;
+            di;
+            udi;
+            li;
+            uli;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT"];
+    let nothing = "-".to_string();
+    let type_names : Vec<&String> = statements.iter().map(|s| 
+            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+
+    assert_eq!(format!("{:?}", expected_types),
+                format!("{:?}", type_names));
+}
+
+#[test]
+fn global_resolves_types() {
+    let (unit, index) = parse(
+        "
+        VAR_GLOBAL
+            b : BYTE;
+            w : WORD;
+            dw : DWORD;
+            lw : LWORD;
+            si : SINT;
+            usi : USINT;
+            i : INT;
+            ui : UINT;
+            di : DINT;
+            udi : UDINT;
+            li : LINT;
+            uli : ULINT;
+        END_VAR
+        
+        PROGRAM PRG
+            b;
+            w;
+            dw;
+            lw;
+            si;
+            usi;
+            i;
+            ui;
+            di;
+            udi;
+            li;
+            uli;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT"];
+    let nothing = "-".to_string();
+    let type_names : Vec<&String> = statements.iter().map(|s| 
+            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+
+    assert_eq!(format!("{:?}", expected_types),
+                format!("{:?}", type_names));
+}
+
+
+#[test]
+fn resolve_binary_expressions() {
+    let (unit, index) = parse(
+        "
+        VAR_GLOBAL
+            b : BYTE;
+            w : WORD;
+            dw : DWORD;
+            lw : LWORD;
+            si : SINT;
+            usi : USINT;
+            i : INT;
+            ui : UINT;
+            di : DINT;
+            udi : UDINT;
+            li : LINT;
+            uli : ULINT;
+        END_VAR
+        
+        PROGRAM PRG
+            b + b;
+            b + w;
+            b + dw;
+            b + lw;
+            b + si;
+            b + usi;
+            b + i;
+            b + ui;
+            b + di;
+            b + udi;
+            b + li;
+            b + uli;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "SINT", "BYTE", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT"];
+    let nothing = "-".to_string();
+    let type_names : Vec<&String> = statements.iter().map(|s| 
+            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+
+    assert_eq!(format!("{:?}", expected_types),
+                format!("{:?}", type_names));
+}
+
+
+#[test]
+fn complex_expressions_resolve_types() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+            VAR
+                b : BYTE;
+                w : WORD;
+                dw : DWORD;
+                lw : LWORD;
+                si : SINT;
+                usi : USINT;
+                i : INT;
+                ui : UINT;
+                di : DINT;
+                udi : UDINT;
+                li : LINT;
+                uli : ULINT;
+                r : REAL;
+            END_VAR
+
+            b + w * di + li;
+            b + w + di;
+            b + w * di + r;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["LINT", "DINT", "REAL"];
+    let nothing = "-".to_string();
+    let type_names : Vec<&String> = statements.iter().map(|s| 
+            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+
+    assert_eq!(format!("{:?}", expected_types),
+                format!("{:?}", type_names));
+}
+
+
+#[test]
+fn qualified_expressions_resolve_types() {
+    let (unit, index) = parse(
+        "
+         PROGRAM Other
+            VAR_INPUT
+                b : BYTE;
+                w : WORD;
+                dw : DWORD;
+                lw : LWORD;
+            END_VAR
+        END_PROGRAM   
+
+        PROGRAM PRG
+            Other.b;
+            Other.w;
+            Other.dw;
+            Other.lw;
+            Other.b + Other.w;
+            Other.b + Other.w + Other.dw;
+            Other.b + Other.w + Other.dw + Other.lw;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "BYTE", "WORD", "DWORD", "LWORD"];
+    let nothing = "-".to_string();
+    let type_names : Vec<&String> = statements.iter().map(|s| 
+            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+
+    assert_eq!(format!("{:?}", expected_types),
+                format!("{:?}", type_names));
+}
+
+
+#[test]
+fn pou_expressions_resolve_types() {
+    let (unit, index) = parse(
+        "
+        PROGRAM OtherPrg
+        END_PROGRAM   
+
+        FUNCTION OtherFunc
+        END_FUNCTION
+
+        FUNCTION_BLOCK OtherFuncBlock
+        END_FUNCTION_BLOCK
+
+        PROGRAM PRG
+            OtherPrg;
+            OtherFunc;
+            OtherFuncBlock;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[3].statements;
+
+    let expected_types = vec!["OtherPrg", "OtherFunc", "OtherFuncBlock"];
+    let nothing = "-".to_string();
+    let type_names : Vec<&String> = statements.iter().map(|s| 
+            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+
+    assert_eq!(format!("{:?}", expected_types),
+                format!("{:?}", type_names));
+}
+
+

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -1,0 +1,48 @@
+use crate::{resolver::{tests::{annotate, parse}}};
+
+
+#[test]
+fn binary_expressions_resolves_types() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+            1 + 2;
+            1 + 2000;
+            2000 + 1;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["BYTE", "UINT", "UINT"];
+    for (i, s) in statements.iter().enumerate() {
+        assert_eq!(
+            Some(&expected_types[i].to_string()),
+            annotations.type_map.get(&s.get_id()),
+            "{:#?}",
+            s
+        );
+    }
+}
+
+#[test]
+fn binary_expressions_resolves_types_with_floats() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+            1 + 2.2;
+            1.1 + 2000;
+            2000.0 + 1.0;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["REAL", "REAL", "REAL"];
+    for (i, s) in statements.iter().enumerate() {
+        assert_eq!(
+            Some(&expected_types[i].to_string()),
+            annotations.type_map.get(&s.get_id()),
+            "{:#?}",
+            s
+        );
+    }
+}

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -1,6 +1,11 @@
+use core::panic;
+
 use crate::{
     ast::Statement,
-    resolver::tests::{annotate, parse},
+    resolver::{
+        tests::{annotate, parse},
+        AnnotationMap,
+    },
 };
 
 #[test]
@@ -447,7 +452,6 @@ fn qualified_expressions_to_structs_resolve_types() {
         END_PROGRAM",
     );
 
-    println!("{:#?}", unit);
     let annotations = annotate(&unit, index);
     let statements = &unit.implementations[0].statements;
 
@@ -470,4 +474,242 @@ fn qualified_expressions_to_structs_resolve_types() {
         .collect();
 
     assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
+}
+
+#[test]
+fn qualified_expressions_to_inlined_structs_resolve_types() {
+    let (unit, index) = parse(
+        "
+        PROGRAM PRG
+            VAR 
+                mys : STRUCT
+                    b : BYTE;
+                    w : WORD;
+                    dw : DWORD;
+                    lw : LWORD;
+                END_STRUCT;
+            END_VAR
+            mys;
+            mys.b;
+            mys.w;
+            mys.dw;
+            mys.lw;
+        END_PROGRAM",
+    );
+
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["__PRG_mys", "BYTE", "WORD", "DWORD", "LWORD"];
+    let nothing = "-".to_string();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
+
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
+}
+
+#[test]
+fn qualified_expressions_to_aliased_structs_resolve_types() {
+    let (unit, index) = parse(
+        "
+        TYPE NextStruct: STRUCT
+            b : BYTE;
+            w : WORD;
+            dw : DWORD;
+            lw : LWORD;
+        END_STRUCT
+        END_TYPE
+ 
+        TYPE MyStruct: STRUCT
+            b : BYTE;
+            w : WORD;
+            dw : DWORD;
+            lw : LWORD;
+            next : AliasedNextStruct;
+        END_STRUCT
+        END_TYPE
+
+        TYPE AliasedMyStruct : MyStruct; END_TYPE
+        TYPE AliasedNextStruct : NextStruct; END_TYPE
+
+        PROGRAM PRG
+            VAR 
+                mys : AliasedMyStruct;
+            END_VAR
+            mys;
+            mys.b;
+            mys.w;
+            mys.dw;
+            mys.lw;
+            mys.next;
+            mys.next.b;
+            mys.next.w;
+            mys.next.dw;
+            mys.next.lw;
+        END_PROGRAM",
+    );
+
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec![
+        "MyStruct",
+        "BYTE",
+        "WORD",
+        "DWORD",
+        "LWORD",
+        "NextStruct",
+        "BYTE",
+        "WORD",
+        "DWORD",
+        "LWORD",
+    ];
+    let nothing = "-".to_string();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
+
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
+}
+
+#[test]
+fn function_parameter_assignments_resolve_types() {
+    let (unit, index) = parse(
+        "
+        FUNCTION foo : MyType
+            VAR_INPUT
+                x : INT;
+                y : INT;
+            END_VAR
+        END_FUNCTION
+
+        PROGRAM PRG
+            foo(x := 3, y := 6);
+        END_PROGRAM
+        
+        TYPE MyType: INT; END_TYPE
+        ",
+    );
+
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[1].statements;
+
+    assert_eq!(
+        annotations.type_map.get(&statements[0].get_id()),
+        Some(&"INT".to_string())
+    );
+    if let Statement::CallStatement {
+        operator,
+        parameters,
+        ..
+    } = &statements[0]
+    {
+        assert_eq!(
+            annotations.type_map.get(&operator.get_id()),
+            Some(&"foo".to_string())
+        );
+
+        if let Some(Statement::ExpressionList { expressions, .. }) = &**parameters {
+            if let Statement::Assignment { left, right, .. } = &expressions[0] {
+                assert_eq!(
+                    annotations.type_map.get(&left.get_id()),
+                    Some(&"INT".to_string())
+                );
+                assert_eq!(
+                    annotations.type_map.get(&right.get_id()),
+                    Some(&"BYTE".to_string())
+                );
+            } else {
+                panic!("assignment expected")
+            }
+        } else {
+            panic!("expression list expected")
+        }
+    } else {
+        panic!("call statement");
+    }
+}
+
+#[test]
+fn nested_function_parameter_assignments_resolve_types() {
+    let (unit, index) = parse(
+        "
+        FUNCTION foo : INT
+            VAR_INPUT
+                x : INT;
+                y : BOOL;
+            END_VAR
+        END_FUNCTION
+
+        FUNCTION baz : DINT
+            VAR_INPUT
+                x : DINT;
+                y : DINT;
+            END_VAR
+        END_FUNCTION
+
+
+        PROGRAM PRG
+            VAR r: REAL; END_VAR
+            foo(x := baz(x := 200, y := FALSE), y := baz(x := 200, y := TRUE) + r);
+        END_PROGRAM",
+    );
+
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[2].statements;
+    if let Statement::CallStatement { parameters, .. } = &statements[0] {
+        //check the two parameters
+        assert_parameter_assignment(parameters, 0, "INT", "DINT", &annotations);
+        assert_parameter_assignment(parameters, 1, "BOOL", "REAL", &annotations);
+
+        //check the inner call in the first parameter assignment of the outer call `x := baz(...)`
+        if let Statement::Assignment { right, .. } = get_expression_from_list(parameters, 0) {
+            if let Statement::CallStatement { parameters, .. } = right.as_ref() {
+                // the left side here should be `x` - so lets see if it got mixed up with the outer call's `x`
+                assert_parameter_assignment(parameters, 0, "DINT", "BYTE", &annotations);
+            } else {
+                panic!("inner call")
+            }
+        } else {
+            panic!("assignment");
+        }
+    } else {
+        panic!("call statement")
+    }
+}
+
+fn get_expression_from_list(stmt: &Option<Statement>, index: usize) -> &Statement {
+    if let Some(Statement::ExpressionList { expressions, .. }) = stmt {
+        &expressions[index]
+    } else {
+        panic!("no expression_list, found {:#?}", stmt)
+    }
+}
+
+fn assert_parameter_assignment(
+    parameters: &Option<Statement>,
+    param_index: usize,
+    left_type: &str,
+    right_type: &str,
+    annotations: &AnnotationMap,
+) {
+    if let Some(Statement::ExpressionList { expressions, .. }) = parameters {
+        if let Statement::Assignment { left, right, .. } = &expressions[param_index] {
+            assert_eq!(
+                annotations.type_map.get(&left.get_id()),
+                Some(&left_type.to_string())
+            );
+            assert_eq!(
+                annotations.type_map.get(&right.get_id()),
+                Some(&right_type.to_string())
+            );
+        } else {
+            panic!("assignment expected")
+        }
+    } else {
+        panic!("expression list expected")
+    }
 }

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -250,9 +250,9 @@ fn qualified_expressions_resolve_types() {
         END_PROGRAM",
     );
     let annotations = annotate(&unit, index);
-    let statements = &unit.implementations[0].statements;
+    let statements = &unit.implementations[1].statements;
 
-    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "BYTE", "WORD", "DWORD", "LWORD"];
+    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "WORD", "DWORD", "LWORD"];
     let nothing = "-".to_string();
     let type_names : Vec<&String> = statements.iter().map(|s| 
             annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -225,6 +225,50 @@ fn complex_expressions_resolve_types() {
                 format!("{:?}", type_names));
 }
 
+#[test]
+fn array_expressions_resolve_types() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+            VAR
+                i : ARRAY[0..10] OF INT;
+                y : ARRAY[0..10] OF MyInt;
+                a : MyIntArray;
+                b : MyAliasArray;
+            END_VAR
+
+            i;
+            i[2];
+
+            y;
+            y[2];
+
+            a;
+            a[2];
+
+            b;
+            b[2];
+        END_PROGRAM
+        
+        TYPE MyInt: INT := 7; END_TYPE 
+        TYPE MyIntArray: ARRAY[0..10] OF INT := 7; END_TYPE 
+        TYPE MyAliasArray: ARRAY[0..10] OF MyInt := 7; END_TYPE 
+
+        ",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["__PRG_i", "INT", "__PRG_y", "INT", "MyIntArray", "INT", "MyAliasArray", "INT"];
+    let nothing = "-".to_string();
+    let type_names : Vec<&String> = statements.iter().map(|s| 
+            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+
+    assert_eq!(format!("{:?}", expected_types),
+                format!("{:?}", type_names));
+}
+
+
+
 
 #[test]
 fn qualified_expressions_resolve_types() {

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -1,5 +1,7 @@
-use crate::{resolver::{tests::{annotate, parse}}};
-
+use crate::{
+    ast::Statement,
+    resolver::tests::{annotate, parse},
+};
 
 #[test]
 fn binary_expressions_resolves_types() {
@@ -47,8 +49,6 @@ fn binary_expressions_resolves_types_with_floats() {
     }
 }
 
-
-
 #[test]
 fn local_variables_resolves_types() {
     let (unit, index) = parse(
@@ -85,13 +85,17 @@ fn local_variables_resolves_types() {
     let annotations = annotate(&unit, index);
     let statements = &unit.implementations[0].statements;
 
-    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT"];
+    let expected_types = vec![
+        "BYTE", "WORD", "DWORD", "LWORD", "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT",
+        "ULINT",
+    ];
     let nothing = "-".to_string();
-    let type_names : Vec<&String> = statements.iter().map(|s| 
-            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
 
-    assert_eq!(format!("{:?}", expected_types),
-                format!("{:?}", type_names));
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
 }
 
 #[test]
@@ -131,15 +135,18 @@ fn global_resolves_types() {
     let annotations = annotate(&unit, index);
     let statements = &unit.implementations[0].statements;
 
-    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT"];
+    let expected_types = vec![
+        "BYTE", "WORD", "DWORD", "LWORD", "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT",
+        "ULINT",
+    ];
     let nothing = "-".to_string();
-    let type_names : Vec<&String> = statements.iter().map(|s| 
-            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
 
-    assert_eq!(format!("{:?}", expected_types),
-                format!("{:?}", type_names));
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
 }
-
 
 #[test]
 fn resolve_binary_expressions() {
@@ -178,15 +185,18 @@ fn resolve_binary_expressions() {
     let annotations = annotate(&unit, index);
     let statements = &unit.implementations[0].statements;
 
-    let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "SINT", "BYTE", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT"];
+    let expected_types = vec![
+        "BYTE", "WORD", "DWORD", "LWORD", "SINT", "BYTE", "INT", "UINT", "DINT", "UDINT", "LINT",
+        "ULINT",
+    ];
     let nothing = "-".to_string();
-    let type_names : Vec<&String> = statements.iter().map(|s| 
-            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
 
-    assert_eq!(format!("{:?}", expected_types),
-                format!("{:?}", type_names));
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
 }
-
 
 #[test]
 fn complex_expressions_resolve_types() {
@@ -218,11 +228,12 @@ fn complex_expressions_resolve_types() {
 
     let expected_types = vec!["LINT", "DINT", "REAL"];
     let nothing = "-".to_string();
-    let type_names : Vec<&String> = statements.iter().map(|s| 
-            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
 
-    assert_eq!(format!("{:?}", expected_types),
-                format!("{:?}", type_names));
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
 }
 
 #[test]
@@ -258,17 +269,24 @@ fn array_expressions_resolve_types() {
     let annotations = annotate(&unit, index);
     let statements = &unit.implementations[0].statements;
 
-    let expected_types = vec!["__PRG_i", "INT", "__PRG_y", "INT", "MyIntArray", "INT", "MyAliasArray", "INT"];
+    let expected_types = vec![
+        "__PRG_i",
+        "INT",
+        "__PRG_y",
+        "INT",
+        "MyIntArray",
+        "INT",
+        "MyAliasArray",
+        "INT",
+    ];
     let nothing = "-".to_string();
-    let type_names : Vec<&String> = statements.iter().map(|s| 
-            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
 
-    assert_eq!(format!("{:?}", expected_types),
-                format!("{:?}", type_names));
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
 }
-
-
-
 
 #[test]
 fn qualified_expressions_resolve_types() {
@@ -298,13 +316,13 @@ fn qualified_expressions_resolve_types() {
 
     let expected_types = vec!["BYTE", "WORD", "DWORD", "LWORD", "WORD", "DWORD", "LWORD"];
     let nothing = "-".to_string();
-    let type_names : Vec<&String> = statements.iter().map(|s| 
-            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
 
-    assert_eq!(format!("{:?}", expected_types),
-                format!("{:?}", type_names));
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
 }
-
 
 #[test]
 fn pou_expressions_resolve_types() {
@@ -330,11 +348,126 @@ fn pou_expressions_resolve_types() {
 
     let expected_types = vec!["OtherPrg", "OtherFunc", "OtherFuncBlock"];
     let nothing = "-".to_string();
-    let type_names : Vec<&String> = statements.iter().map(|s| 
-            annotations.type_map.get(&s.get_id()).unwrap_or(&nothing)).collect();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
 
-    assert_eq!(format!("{:?}", expected_types),
-                format!("{:?}", type_names));
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
 }
 
+#[test]
+fn assignment_expressions_resolve_types() {
+    let (unit, index) = parse(
+        "
+        PROGRAM PRG
+            VAR
+                x : INT;
+                y : BYTE;
+                z : LWORD;
+            END_VAR
 
+            x := y;
+            z := x;
+        END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let nothing = "-".to_string();
+    let expected_types = vec![&nothing, &nothing];
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
+
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
+
+    if let Statement::Assignment { left, right, .. } = &statements[0] {
+        assert_eq!(
+            annotations.type_map.get(&left.get_id()),
+            Some(&"INT".to_string())
+        );
+        assert_eq!(
+            annotations.type_map.get(&right.get_id()),
+            Some(&"BYTE".to_string())
+        );
+    } else {
+        panic!("expected assignment")
+    }
+    if let Statement::Assignment { left, right, .. } = &statements[1] {
+        assert_eq!(
+            annotations.type_map.get(&left.get_id()),
+            Some(&"LWORD".to_string())
+        );
+        assert_eq!(
+            annotations.type_map.get(&right.get_id()),
+            Some(&"INT".to_string())
+        );
+    } else {
+        panic!("expected assignment")
+    }
+}
+
+#[test]
+fn qualified_expressions_to_structs_resolve_types() {
+    let (unit, index) = parse(
+        "
+        TYPE NextStruct: STRUCT
+            b : BYTE;
+            w : WORD;
+            dw : DWORD;
+            lw : LWORD;
+        END_STRUCT
+        END_TYPE
+ 
+        TYPE MyStruct: STRUCT
+            b : BYTE;
+            w : WORD;
+            dw : DWORD;
+            lw : LWORD;
+            next : NextStruct;
+        END_STRUCT
+        END_TYPE
+
+        PROGRAM PRG
+            VAR 
+                mys : MyStruct;
+            END_VAR
+            mys;
+            mys.b;
+            mys.w;
+            mys.dw;
+            mys.lw;
+            mys.next;
+            mys.next.b;
+            mys.next.w;
+            mys.next.dw;
+            mys.next.lw;
+        END_PROGRAM",
+    );
+
+    println!("{:#?}", unit);
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec![
+        "MyStruct",
+        "BYTE",
+        "WORD",
+        "DWORD",
+        "LWORD",
+        "NextStruct",
+        "BYTE",
+        "WORD",
+        "DWORD",
+        "LWORD",
+    ];
+    let nothing = "-".to_string();
+    let type_names: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&nothing))
+        .collect();
+
+    assert_eq!(format!("{:?}", expected_types), format!("{:?}", type_names));
+}

--- a/src/resolver/tests/resolve_literals_tests.rs
+++ b/src/resolver/tests/resolve_literals_tests.rs
@@ -1,5 +1,4 @@
-use crate::{resolver::{tests::{annotate, parse}}};
-
+use crate::resolver::tests::{annotate, parse};
 
 #[test]
 fn bool_literals_are_annotated() {
@@ -33,7 +32,6 @@ fn string_literals_are_annotated() {
     let annotations = annotate(&unit, index);
     let statements = &unit.implementations[0].statements;
 
-
     for s in statements.iter() {
         assert_eq!(
             Some(&"STRING".to_string()),
@@ -54,8 +52,17 @@ fn int_literals_are_annotated() {
     );
     let annotations = annotate(&unit, index);
     let statements = &unit.implementations[0].statements;
-    
-    let expected_types = vec!["BYTE", "UINT", "UDINT", "ULINT", "DATE_AND_TIME", "DATE_AND_TIME", "DATE", "DATE"];
+
+    let expected_types = vec![
+        "BYTE",
+        "UINT",
+        "UDINT",
+        "ULINT",
+        "DATE_AND_TIME",
+        "DATE_AND_TIME",
+        "DATE",
+        "DATE",
+    ];
     for (i, s) in statements.iter().enumerate() {
         assert_eq!(
             Some(&expected_types[i].to_string()),
@@ -83,7 +90,16 @@ fn date_literals_are_annotated() {
     let annotations = annotate(&unit, index);
     let statements = &unit.implementations[0].statements;
 
-    let expected_types = vec!["TIME", "TIME", "TIME_OF_DAY", "TIME_OF_DAY", "DATE_AND_TIME", "DATE_AND_TIME", "DATE", "DATE"];
+    let expected_types = vec![
+        "TIME",
+        "TIME",
+        "TIME_OF_DAY",
+        "TIME_OF_DAY",
+        "DATE_AND_TIME",
+        "DATE_AND_TIME",
+        "DATE",
+        "DATE",
+    ];
     for (i, s) in statements.iter().enumerate() {
         assert_eq!(
             Some(&expected_types[i].to_string()),

--- a/src/resolver/tests/resolve_literals_tests.rs
+++ b/src/resolver/tests/resolve_literals_tests.rs
@@ -1,0 +1,117 @@
+use crate::{resolver::{tests::{annotate, parse}}};
+
+
+#[test]
+fn bool_literals_are_annotated() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+                TRUE;
+                FALSE;
+            END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    assert_eq!(
+        Some(&"BOOL".to_string()),
+        annotations.type_map.get(&statements[0].get_id())
+    );
+    assert_eq!(
+        Some(&"BOOL".to_string()),
+        annotations.type_map.get(&statements[1].get_id())
+    );
+}
+
+#[test]
+fn string_literals_are_annotated() {
+    let (unit, index) = parse(
+        r#"PROGRAM PRG
+                "abc";
+                "xyz";
+            END_PROGRAM"#,
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+
+    for s in statements.iter() {
+        assert_eq!(
+            Some(&"STRING".to_string()),
+            annotations.type_map.get(&s.get_id())
+        );
+    }
+}
+
+#[test]
+fn int_literals_are_annotated() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+                1;
+                1000;
+                1000000;
+                10000000000;
+            END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+    
+    let expected_types = vec!["BYTE", "UINT", "UDINT", "ULINT", "DATE_AND_TIME", "DATE_AND_TIME", "DATE", "DATE"];
+    for (i, s) in statements.iter().enumerate() {
+        assert_eq!(
+            Some(&expected_types[i].to_string()),
+            annotations.type_map.get(&s.get_id()),
+            "{:#?}",
+            s
+        );
+    }
+}
+
+#[test]
+fn date_literals_are_annotated() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+                T#12.4d;
+                TIME#-12m;
+                TOD#00:00:12;
+                TIME_OF_DAY#04:16:22;
+                DATE_AND_TIME#1984-10-01-16:40:22; 
+                DT#2021-04-20-22:33:14; 
+                DATE#1984-10-01; 
+                D#2021-04-20; 
+            END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["TIME", "TIME", "TIME_OF_DAY", "TIME_OF_DAY", "DATE_AND_TIME", "DATE_AND_TIME", "DATE", "DATE"];
+    for (i, s) in statements.iter().enumerate() {
+        assert_eq!(
+            Some(&expected_types[i].to_string()),
+            annotations.type_map.get(&s.get_id()),
+            "{:#?}",
+            s
+        );
+    }
+}
+
+#[test]
+fn real_literals_are_annotated() {
+    let (unit, index) = parse(
+        "PROGRAM PRG
+                3.1415;
+                1.0;
+            END_PROGRAM",
+    );
+    let annotations = annotate(&unit, index);
+    let statements = &unit.implementations[0].statements;
+
+    let expected_types = vec!["REAL", "REAL"];
+    for (i, s) in statements.iter().enumerate() {
+        assert_eq!(
+            Some(&expected_types[i].to_string()),
+            annotations.type_map.get(&s.get_id()),
+            "{:#?}",
+            s
+        );
+    }
+}

--- a/src/resolver/tests/resolve_literals_tests.rs
+++ b/src/resolver/tests/resolve_literals_tests.rs
@@ -48,20 +48,17 @@ fn int_literals_are_annotated() {
                 1000;
                 1000000;
                 10000000000;
+                -1;
+                -1000;
+                -1000000;
+                -10000000000;
             END_PROGRAM",
     );
     let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
-        "BYTE",
-        "UINT",
-        "UDINT",
-        "ULINT",
-        "DATE_AND_TIME",
-        "DATE_AND_TIME",
-        "DATE",
-        "DATE",
+        "BYTE", "UINT", "UDINT", "ULINT", "SINT", "INT", "DINT", "LINT",
     ];
     for (i, s) in statements.iter().enumerate() {
         assert_eq!(

--- a/src/resolver/tests/resolve_literals_tests.rs
+++ b/src/resolver/tests/resolve_literals_tests.rs
@@ -8,7 +8,7 @@ fn bool_literals_are_annotated() {
                 FALSE;
             END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     assert_eq!(
@@ -29,7 +29,7 @@ fn string_literals_are_annotated() {
                 "xyz";
             END_PROGRAM"#,
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     for s in statements.iter() {
@@ -50,7 +50,7 @@ fn int_literals_are_annotated() {
                 10000000000;
             END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
@@ -87,7 +87,7 @@ fn date_literals_are_annotated() {
                 D#2021-04-20; 
             END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec![
@@ -118,7 +118,7 @@ fn real_literals_are_annotated() {
                 1.0;
             END_PROGRAM",
     );
-    let annotations = annotate(&unit, index);
+    let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
     let expected_types = vec!["REAL", "REAL"];

--- a/src/resolver/tests/resolve_literals_tests.rs
+++ b/src/resolver/tests/resolve_literals_tests.rs
@@ -44,30 +44,27 @@ fn string_literals_are_annotated() {
 fn int_literals_are_annotated() {
     let (unit, index) = parse(
         "PROGRAM PRG
-                1;
-                1000;
-                1000000;
-                10000000000;
-                -1;
-                -1000;
-                -1000000;
-                -10000000000;
+                0;
+                127;
+                128;
+                32767;
+                32768;
+                2147483647;
+                2147483648;
             END_PROGRAM",
     );
     let annotations = annotate(&unit, &index);
     let statements = &unit.implementations[0].statements;
 
-    let expected_types = vec![
-        "BYTE", "UINT", "UDINT", "ULINT", "SINT", "INT", "DINT", "LINT",
-    ];
-    for (i, s) in statements.iter().enumerate() {
-        assert_eq!(
-            Some(&expected_types[i].to_string()),
-            annotations.type_map.get(&s.get_id()),
-            "{:#?}",
-            s
-        );
-    }
+    let expected_types = vec!["DINT", "DINT", "DINT", "DINT", "DINT", "DINT", "LINT"];
+
+    let none = "-".to_string();
+    let types: Vec<&String> = statements
+        .iter()
+        .map(|s| annotations.type_map.get(&s.get_id()).unwrap_or(&none))
+        .collect();
+
+    assert_eq!(expected_types, types);
 }
 
 #[test]

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -160,6 +160,7 @@ impl DataTypeInformation {
     }
 }
 
+
 pub fn get_builtin_types() -> Vec<DataType> {
     vec![
         DataType {

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -8,11 +8,32 @@ use crate::{
 
 pub const DEFAULT_STRING_LEN: u32 = 80;
 
-//CheckRan­geSigned, CheckLRangeSigned or CheckRangeUnsigned, CheckLRangeUnsigned
 pub const RANGE_CHECK_S_FN: &str = "CheckRangeSigned";
 pub const RANGE_CHECK_LS_FN: &str = "CheckLRangeSigned";
 pub const RANGE_CHECK_U_FN: &str = "CheckRangeUnsigned";
 pub const RANGE_CHECK_LU_FN: &str = "CheckLRangeUnsigned";
+
+pub const BOOL_TYPE: &str = "BOOL";
+pub const BYTE_TYPE: &str = "BYTE";
+pub const SINT_TYPE: &str = "SINT";
+pub const USINT_TYPE: &str = "USINT";
+pub const WORD_TYPE: &str = "WORD";
+pub const INT_TYPE: &str = "INT";
+pub const UINT_TYPE: &str = "UINT";
+pub const DWORD_TYPE: &str = "DWORD";
+pub const DINT_TYPE: &str = "DINT";
+pub const UDINT_TYPE: &str = "UDINT";
+pub const LWORD_TYPE: &str = "LWORD";
+pub const LINT_TYPE: &str = "LINT";
+pub const DATE_TYPE: &str = "DATE";
+pub const TIME_TYPE: &str = "TIME";
+pub const DATE_AND_TIME_TYPE: &str = "DATE_AND_TIME";
+pub const TIME_OF_DAY_TYPE: &str = "TIME_OF_DAY";
+pub const ULINT_TYPE: &str = "ULINT";
+pub const REAL_TYPE: &str = "REAL";
+pub const LREAL_TYPE: &str = "LREAL";
+pub const STRING_TYPE: &str = "STRING";
+pub const WSTRING_TYPE: &str = "WSTRING";
 
 #[derive(Debug, PartialEq)]
 pub struct DataType {
@@ -171,176 +192,176 @@ pub fn get_builtin_types() -> Vec<DataType> {
             information: DataTypeInformation::Void,
         },
         DataType {
-            name: "BOOL".into(),
+            name: BOOL_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "BOOL".into(),
+                name: BOOL_TYPE.into(),
                 signed: true,
                 size: 1,
             },
         },
         DataType {
-            name: "BYTE".into(),
+            name: BYTE_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "BYTE".into(),
+                name: BYTE_TYPE.into(),
                 signed: false,
                 size: 8,
             },
         },
         DataType {
-            name: "SINT".into(),
+            name: SINT_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "SINT".into(),
+                name: SINT_TYPE.into(),
                 signed: true,
                 size: 8,
             },
         },
         DataType {
-            name: "USINT".into(),
+            name: USINT_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "USINT".into(),
+                name: USINT_TYPE.into(),
                 signed: false,
                 size: 8,
             },
         },
         DataType {
-            name: "WORD".into(),
+            name: WORD_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "WORD".into(),
+                name: WORD_TYPE.into(),
                 signed: false,
                 size: 16,
             },
         },
         DataType {
-            name: "INT".into(),
+            name: INT_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "INT".into(),
+                name: INT_TYPE.into(),
                 signed: true,
                 size: 16,
             },
         },
         DataType {
-            name: "UINT".into(),
+            name: UINT_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "UINT".into(),
+                name: UINT_TYPE.into(),
                 signed: false,
                 size: 16,
             },
         },
         DataType {
-            name: "DWORD".into(),
+            name: DWORD_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "DWORD".into(),
+                name: DWORD_TYPE.into(),
                 signed: false,
                 size: 32,
             },
         },
         DataType {
-            name: "DINT".into(),
+            name: DINT_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "DINT".into(),
+                name: DINT_TYPE.into(),
                 signed: true,
                 size: 32,
             },
         },
         DataType {
-            name: "UDINT".into(),
+            name: UDINT_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "UDINT".into(),
+                name: UDINT_TYPE.into(),
                 signed: false,
                 size: 32,
             },
         },
         DataType {
-            name: "LWORD".into(),
+            name: LWORD_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "LWORD".into(),
+                name: LWORD_TYPE.into(),
                 signed: false,
                 size: 64,
             },
         },
         DataType {
-            name: "LINT".into(),
+            name: LINT_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "LINT".into(),
+                name: LINT_TYPE.into(),
                 signed: true,
                 size: 64,
             },
         },
         DataType {
-            name: "DATE".into(),
+            name: DATE_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "DATE".into(),
+                name: DATE_TYPE.into(),
                 signed: true,
                 size: 64,
             },
         },
         DataType {
-            name: "TIME".into(),
+            name: TIME_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "TIME".into(),
+                name: TIME_TYPE.into(),
                 signed: true,
                 size: 64,
             },
         },
         DataType {
-            name: "DATE_AND_TIME".into(),
+            name: DATE_AND_TIME_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "DATE_AND_TIME".into(),
+                name: DATE_AND_TIME_TYPE.into(),
                 signed: true,
                 size: 64,
             },
         },
         DataType {
-            name: "TIME_OF_DAY".into(),
+            name: TIME_OF_DAY_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "TIME_OF_DAY".into(),
+                name: TIME_OF_DAY_TYPE.into(),
                 signed: true,
                 size: 64,
             },
         },
         DataType {
-            name: "ULINT".into(),
+            name: ULINT_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Integer {
-                name: "ULINT".into(),
+                name: ULINT_TYPE.into(),
                 signed: false,
                 size: 64,
             },
         },
         DataType {
-            name: "REAL".into(),
+            name: REAL_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Float {
-                name: "REAL".into(),
+                name: REAL_TYPE.into(),
                 size: 32,
             },
         },
         DataType {
-            name: "LREAL".into(),
+            name: LREAL_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::Float {
-                name: "LREAL".into(),
+                name: LREAL_TYPE.into(),
                 size: 64,
             },
         },
         DataType {
-            name: "STRING".into(),
+            name: STRING_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::String {
                 size: DEFAULT_STRING_LEN + 1,
@@ -348,7 +369,7 @@ pub fn get_builtin_types() -> Vec<DataType> {
             },
         },
         DataType {
-            name: "WSTRING".into(),
+            name: WSTRING_TYPE.into(),
             initial_value: None,
             information: DataTypeInformation::String {
                 size: DEFAULT_STRING_LEN + 1,
@@ -393,14 +414,14 @@ fn is_same_type_nature(ltype: &DataTypeInformation, rtype: &DataTypeInformation)
 
 fn get_real_type() -> DataTypeInformation {
     DataTypeInformation::Float {
-        name: "REAL".into(),
+        name: REAL_TYPE.into(),
         size: 32,
     }
 }
 
 fn get_lreal_type() -> DataTypeInformation {
     DataTypeInformation::Float {
-        name: "LREAL".into(),
+        name: LREAL_TYPE.into(),
         size: 64,
     }
 }
@@ -439,12 +460,12 @@ pub fn get_bigger_type_borrow<'t>(
         }
     } else {
         let real_type = index
-            .get_type("REAL")
+            .get_type(REAL_TYPE)
             .map(|it| it.get_type_information())
             .unwrap();
         let real_size = real_type.get_size();
         if ltype.get_size() > real_size || rtype.get_size() > real_size {
-            index.get_type("LREAL").unwrap().get_type_information()
+            index.get_type(LREAL_TYPE).unwrap().get_type_information()
         } else {
             real_type
         }
@@ -459,14 +480,14 @@ pub fn get_signed_type<'t>(
 ) -> Option<&'t DataTypeInformation> {
     if data_type.is_int() {
         let signed_type = match data_type.get_name() {
-            "BYTE" => "SINT",
-            "USINT" => "SINT",
-            "WORD" => "INT",
-            "UINT" => "INT",
-            "DWORD" => "DINT",
-            "UDINT" => "DINT",
-            "ULINT" => "LINT",
-            "LWORD" => "LINT",
+            BYTE_TYPE => SINT_TYPE,
+            USINT_TYPE => SINT_TYPE,
+            WORD_TYPE => INT_TYPE,
+            UINT_TYPE => INT_TYPE,
+            DWORD_TYPE => DINT_TYPE,
+            UDINT_TYPE => DINT_TYPE,
+            ULINT_TYPE => LINT_TYPE,
+            LWORD_TYPE => LINT_TYPE,
             _ => data_type.get_name(),
         };
         return index
@@ -475,4 +496,50 @@ pub fn get_signed_type<'t>(
             .map(|t| t.get_type_information());
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ast::CompilationUnit,
+        index::visitor::visit,
+        typesystem::{
+            get_signed_type, BYTE_TYPE, DINT_TYPE, DWORD_TYPE, INT_TYPE, LINT_TYPE, LWORD_TYPE,
+            SINT_TYPE, UDINT_TYPE, UINT_TYPE, ULINT_TYPE, USINT_TYPE, WORD_TYPE,
+        },
+    };
+
+    macro_rules! assert_signed_type {
+        ($expected:expr, $actual:expr, $index:expr) => {
+            assert_eq!(
+                $index.find_type_information($expected).as_ref(),
+                get_signed_type(
+                    $index.find_type_information($actual).as_ref().unwrap(),
+                    &$index
+                )
+            );
+        };
+    }
+
+    #[test]
+    pub fn signed_types_tests() {
+        // Given an initialized index
+        let index = visit(&CompilationUnit::default());
+        assert_signed_type!(SINT_TYPE, BYTE_TYPE, index);
+        assert_signed_type!(SINT_TYPE, USINT_TYPE, index);
+        assert_signed_type!(INT_TYPE, WORD_TYPE, index);
+        assert_signed_type!(INT_TYPE, UINT_TYPE, index);
+        assert_signed_type!(DINT_TYPE, DWORD_TYPE, index);
+        assert_signed_type!(DINT_TYPE, UDINT_TYPE, index);
+        assert_signed_type!(LINT_TYPE, ULINT_TYPE, index);
+        assert_signed_type!(LINT_TYPE, LWORD_TYPE, index);
+
+        assert_eq!(
+            None,
+            get_signed_type(
+                index.find_type_information("STRING").as_ref().unwrap(),
+                &index
+            )
+        );
+    }
 }

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use std::ops::Range;
 
-use crate::{ast::{Dimension, Statement}, index::Index};
+use crate::{
+    ast::{Dimension, Statement},
+    index::Index,
+};
 
 pub const DEFAULT_STRING_LEN: u32 = 80;
 
@@ -159,7 +162,6 @@ impl DataTypeInformation {
         }
     }
 }
-
 
 pub fn get_builtin_types() -> Vec<DataType> {
     vec![
@@ -435,8 +437,11 @@ pub fn get_bigger_type_borrow<'t>(
         } else {
             ltype
         }
-    } else { 
-        let real_type = index.get_type("REAL").map(|it| it.get_type_information()).unwrap();
+    } else {
+        let real_type = index
+            .get_type("REAL")
+            .map(|it| it.get_type_information())
+            .unwrap();
         let real_size = real_type.get_size();
         if ltype.get_size() > real_size || rtype.get_size() > real_size {
             index.get_type("LREAL").unwrap().get_type_information()
@@ -448,7 +453,10 @@ pub fn get_bigger_type_borrow<'t>(
 
 /// returns the signed version of the given data_type if its a signed int-type
 /// returns the original type if it is no signed int-type
-pub fn get_signed_type<'t>(data_type: &'t DataTypeInformation, index: &'t Index) -> Option<&'t DataTypeInformation> {
+pub fn get_signed_type<'t>(
+    data_type: &'t DataTypeInformation,
+    index: &'t Index,
+) -> Option<&'t DataTypeInformation> {
     if data_type.is_int() {
         let signed_type = match data_type.get_name() {
             "BYTE" => "SINT",
@@ -456,12 +464,15 @@ pub fn get_signed_type<'t>(data_type: &'t DataTypeInformation, index: &'t Index)
             "WORD" => "INT",
             "UINT" => "INT",
             "DWORD" => "DINT",
-            "UDINT" => "DINT", 
+            "UDINT" => "DINT",
             "ULINT" => "LINT",
             "LWORD" => "LINT",
-            _ => data_type.get_name()
+            _ => data_type.get_name(),
         };
-        return index.get_type(signed_type).ok().map(|t| t.get_type_information());
+        return index
+            .get_type(signed_type)
+            .ok()
+            .map(|t| t.get_type_information());
     }
     None
 }


### PR DESCRIPTION
merged master and introduced the discussed issues:

- integer literals are now treated as DINT or LINT.
- negative integer-literals are no longer parsed as Unary-Statements but really parsed as negative numbers

will add issue for:
- currently we cannot derive a correct type name for array-literals and struct-literals