### PR TITLE
Pointer and reference support

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -487,6 +487,10 @@ pub enum Statement {
         access: Box<Statement>,
         id: AstId,
     },
+    PointerAccess {
+        reference: Box<Statement>,
+        id: AstId,
+    },
     BinaryExpression {
         operator: Operator,
         left: Box<Statement>,
@@ -776,6 +780,10 @@ impl Debug for Statement {
                 .field("reference", reference)
                 .field("access", access)
                 .finish(),
+            Statement::PointerAccess { reference, .. } => f
+                .debug_struct("PointerAccess")
+                .field("reference", reference)
+                .finish(),
             Statement::MultipliedStatement {
                 multiplier,
                 element,
@@ -871,6 +879,7 @@ impl Statement {
                 let access_loc = access.get_location();
                 SourceRange::new(reference_loc.range.start..access_loc.range.end)
             }
+            Statement::PointerAccess { reference, .. } => reference.get_location(),
             Statement::MultipliedStatement { location, .. } => location.clone(),
             Statement::CaseCondition { condition, .. } => condition.get_location(),
             Statement::ReturnStatement { location, .. } => location.clone(),
@@ -896,6 +905,7 @@ impl Statement {
             Statement::QualifiedReference { id, .. } => *id,
             Statement::Reference { id, .. } => *id,
             Statement::ArrayAccess { id, .. } => *id,
+            Statement::PointerAccess { id, .. } => *id,
             Statement::BinaryExpression { id, .. } => *id,
             Statement::UnaryExpression { id, .. } => *id,
             Statement::ExpressionList { id, .. } => *id,
@@ -934,7 +944,6 @@ pub enum Operator {
     Or,
     Xor,
     Address,
-    Deref,
 }
 
 impl Display for Operator {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -362,22 +362,30 @@ impl DataType {
         &mut self,
         type_name: String,
     ) -> Option<DataTypeDeclaration> {
-        if let DataType::ArrayType {
-            referenced_type, ..
-        } = self
-        {
-            if let DataTypeDeclaration::DataTypeReference { .. } = **referenced_type {
-                return None;
-            }
-            let new_data_type = DataTypeDeclaration::DataTypeReference {
-                referenced_type: type_name,
-            };
-            let old_data_type = std::mem::replace(referenced_type, Box::new(new_data_type));
-            Some(*old_data_type)
-        } else {
-            None
+        match self {
+            DataType::ArrayType {
+                referenced_type, ..
+            } => replace_reference(referenced_type, type_name),
+            DataType::PointerType {
+                referenced_type, ..
+            } => replace_reference(referenced_type, type_name),
+            _ => None,
         }
     }
+}
+
+fn replace_reference(
+    referenced_type: &mut Box<DataTypeDeclaration>,
+    type_name: String,
+) -> Option<DataTypeDeclaration> {
+    if let DataTypeDeclaration::DataTypeReference { .. } = **referenced_type {
+        return None;
+    }
+    let new_data_type = DataTypeDeclaration::DataTypeReference {
+        referenced_type: type_name,
+    };
+    let old_data_type = std::mem::replace(referenced_type, Box::new(new_data_type));
+    Some(*old_data_type)
 }
 
 #[derive(Clone, PartialEq)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -582,7 +582,7 @@ pub enum Statement {
         location: SourceRange,
         id: AstId,
     },
-    NullStatement {
+    LiteralNull {
         location: SourceRange,
         id: AstId,
     },
@@ -592,7 +592,7 @@ impl Debug for Statement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             Statement::EmptyStatement { .. } => f.debug_struct("EmptyStatement").finish(),
-            Statement::NullStatement { .. } => f.debug_struct("NullStatement").finish(),
+            Statement::LiteralNull { .. } => f.debug_struct("LiteralNull").finish(),
             Statement::LiteralInteger { value, .. } => f
                 .debug_struct("LiteralInteger")
                 .field("value", value)
@@ -816,7 +816,7 @@ impl Statement {
     pub fn get_location(&self) -> SourceRange {
         match self {
             Statement::EmptyStatement { location, .. } => location.clone(),
-            Statement::NullStatement { location, .. } => location.clone(),
+            Statement::LiteralNull { location, .. } => location.clone(),
             Statement::LiteralInteger { location, .. } => location.clone(),
             Statement::LiteralDate { location, .. } => location.clone(),
             Statement::LiteralDateAndTime { location, .. } => location.clone(),
@@ -891,7 +891,7 @@ impl Statement {
     pub fn get_id(&self) -> AstId {
         match self {
             Statement::EmptyStatement { id, .. } => *id,
-            Statement::NullStatement { id, .. } => *id,
+            Statement::LiteralNull { id, .. } => *id,
             Statement::LiteralInteger { id, .. } => *id,
             Statement::LiteralDate { id, .. } => *id,
             Statement::LiteralDateAndTime { id, .. } => *id,

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -802,6 +802,100 @@ fn pre_processing_generates_inline_structs() {
 }
 
 #[test]
+fn pre_processing_generates_inline_pointers() {
+    // GIVEN an inline pointer is declared
+    let lexer = lex(r#"
+        PROGRAM foo
+        VAR
+            inline_pointer: REF_TO INT;
+        END_VAR
+        END_PROGRAM
+        "#);
+    let (mut ast, ..) = parser::parse(lexer);
+
+    // WHEN the AST ist pre-processed
+    crate::ast::pre_process(&mut ast);
+
+    //Pointer
+    //THEN an implicit datatype should have been generated for the array
+    let new_pointer_type = &ast.types[0];
+
+    let expected = &UserTypeDeclaration {
+        data_type: DataType::PointerType {
+            name: Some("__foo_inline_pointer".to_string()),
+            referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
+                referenced_type: "INT".to_string(),
+            }),
+        },
+        initializer: None,
+    };
+    assert_eq!(format!("{:?}", expected), format!("{:?}", new_pointer_type));
+
+    // AND the original variable should now point to the new DataType
+    let var_data_type = &ast.units[0].variable_blocks[0].variables[0].data_type;
+    assert_eq!(
+        &DataTypeDeclaration::DataTypeReference {
+            referenced_type: "__foo_inline_pointer".to_string(),
+        },
+        var_data_type
+    );
+}
+
+#[test]
+fn pre_processing_generates_inline_pointer_to_pointer() {
+    // GIVEN an inline pointer is declared
+    let lexer = lex(r#"
+        PROGRAM foo
+        VAR
+            inline_pointer: REF_TO REF_TO INT;
+        END_VAR
+        END_PROGRAM
+        "#);
+    let (mut ast, ..) = parser::parse(lexer);
+
+    // WHEN the AST ist pre-processed
+    crate::ast::pre_process(&mut ast);
+
+    //Pointer
+    //THEN an implicit datatype should have been generated for the pointer
+
+    // POINTER TO INT
+    let new_pointer_type = &ast.types[0];
+    let expected = &UserTypeDeclaration {
+        data_type: DataType::PointerType {
+            name: Some("__foo_inline_pointer_".to_string()),
+            referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
+                referenced_type: "INT".to_string(),
+            }),
+        },
+        initializer: None,
+    };
+    assert_eq!(format!("{:?}", expected), format!("{:?}", new_pointer_type));
+
+    // Pointer OF Pointer
+    let new_pointer_type = &ast.types[1];
+    let expected = &UserTypeDeclaration {
+        data_type: DataType::PointerType {
+            name: Some("__foo_inline_pointer".to_string()),
+            referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
+                referenced_type: "__foo_inline_pointer_".to_string(),
+            }),
+        },
+        initializer: None,
+    };
+    assert_eq!(format!("{:?}", expected), format!("{:?}", new_pointer_type));
+
+    // AND the original variable should now point to the new DataType
+    let var_data_type = &ast.units[0].variable_blocks[0].variables[0].data_type;
+    assert_eq!(
+        &DataTypeDeclaration::DataTypeReference {
+            referenced_type: "__foo_inline_pointer".to_string(),
+        },
+        var_data_type
+    );
+}
+
+#[test]
 fn pre_processing_generates_inline_arrays() {
     // GIVEN an inline array is declared
     let lexer = lex(r#"

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -295,7 +295,23 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 information,
             )
         }
-        DataType::PointerType { .. } => todo!(),
+        DataType::PointerType {
+            name,
+            referenced_type,
+            ..
+        } => {
+            let inner_type_name = referenced_type.get_name().unwrap();
+            let information = DataTypeInformation::Pointer {
+                name: name.as_ref().unwrap().clone(),
+                inner_type_name: inner_type_name.into(),
+                auto_deref: false,
+            };
+            index.register_type(
+                name.as_ref().unwrap(),
+                type_declatation.initializer.clone(),
+                information,
+            )
+        }
         DataType::StringType {
             name,
             size,

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -295,6 +295,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 information,
             )
         }
+        DataType::PointerType { .. } => todo!(),
         DataType::StringType {
             name,
             size,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -118,6 +118,7 @@ impl<'a> ParseSession<'a> {
             | Token::KeywordVarOutput
             | Token::KeywordVarGlobal
             | Token::KeywordVarInOut
+            | Token::KeywordRef
             | Token::KeywordEndVar
             | Token::KeywordEndProgram
             | Token::KeywordEndFunction
@@ -152,6 +153,10 @@ impl<'a> ParseSession<'a> {
 
     pub fn location(&self) -> SourceRange {
         SourceRange::new(self.range())
+    }
+
+    pub fn last_location(&self) -> SourceRange {
+        SourceRange::new(self.last_range.clone())
     }
 
     pub fn range(&self) -> Range<usize> {

--- a/src/lexer/tests/lexer_tests.rs
+++ b/src/lexer/tests/lexer_tests.rs
@@ -535,6 +535,35 @@ fn wide_string_parsing() {
 }
 
 #[test]
+fn pointers_and_references_keyword() {
+    let mut lexer = lex(r#"
+    POINTER TO x 
+    REF_TO x
+    &x
+    x^
+    "#);
+
+    assert_eq!(lexer.token, KeywordPointer);
+    lexer.advance();
+    assert_eq!(lexer.token, KeywordTo);
+    lexer.advance();
+    assert_eq!(lexer.slice(), "x");
+    lexer.advance();
+    assert_eq!(lexer.token, KeywordRef);
+    lexer.advance();
+    assert_eq!(lexer.slice(), "x");
+    lexer.advance();
+    assert_eq!(lexer.token, OperatorAmp);
+    lexer.advance();
+    assert_eq!(lexer.slice(), "x");
+    lexer.advance();
+    assert_eq!(lexer.slice(), "x");
+    lexer.advance();
+    assert_eq!(lexer.token, OperatorDeref);
+    lexer.advance();
+}
+
+#[test]
 fn multi_named_keywords_without_underscore_test() {
     let mut lexer = lex(
         "VARINPUT VARGLOBAL VARINOUT ENDVAR ENDPROGRAM ENDFUNCTION ENDCASE

--- a/src/lexer/tests/lexer_tests.rs
+++ b/src/lexer/tests/lexer_tests.rs
@@ -539,13 +539,19 @@ fn pointers_and_references_keyword() {
     let mut lexer = lex(r#"
     POINTER TO x 
     REF_TO x
+    REFTO x
     &x
     x^
+    NULL
     "#);
 
     assert_eq!(lexer.token, KeywordPointer);
     lexer.advance();
     assert_eq!(lexer.token, KeywordTo);
+    lexer.advance();
+    assert_eq!(lexer.slice(), "x");
+    lexer.advance();
+    assert_eq!(lexer.token, KeywordRef);
     lexer.advance();
     assert_eq!(lexer.slice(), "x");
     lexer.advance();
@@ -561,12 +567,14 @@ fn pointers_and_references_keyword() {
     lexer.advance();
     assert_eq!(lexer.token, OperatorDeref);
     lexer.advance();
+    assert_eq!(lexer.token, LiteralNull);
+    lexer.advance();
 }
 
 #[test]
 fn multi_named_keywords_without_underscore_test() {
     let mut lexer = lex(
-        "VARINPUT VARGLOBAL VARINOUT ENDVAR ENDPROGRAM ENDFUNCTION ENDCASE
+        "VARINPUT VARGLOBAL VARINOUT REFTO ENDVAR ENDPROGRAM ENDFUNCTION ENDCASE
         VAROUTPUT FUNCTIONBLOCK ENDFUNCTIONBLOCK ENDSTRUCT ENDACTION
         ENDACTIONS ENDIF ENDFOR ENDREPEAT",
     );
@@ -575,7 +583,7 @@ fn multi_named_keywords_without_underscore_test() {
         lexer.advance();
     }
 
-    assert_eq!(lexer.diagnostics.len(), 16);
+    assert_eq!(lexer.diagnostics.len(), 17);
 
     let d1 = lexer.diagnostics.first().unwrap();
     let d2 = lexer.diagnostics.last().unwrap();
@@ -590,5 +598,5 @@ fn multi_named_keywords_without_underscore_test() {
         d2.get_message(),
         "the words in ENDREPEAT should be separated by a '_'"
     );
-    assert_eq!(d2.get_location(), SourceRange::new(167..176));
+    assert_eq!(d2.get_location(), SourceRange::new(173..182));
 }

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -234,6 +234,7 @@ pub enum Token {
     KeywordPointer,
 
     #[token("REF_TO")]
+    #[token("REFTO")]
     KeywordRef,
 
     #[token("ARRAY")]
@@ -322,6 +323,9 @@ pub enum Token {
 
     #[regex("[eE][+-]?[0-9]+")]
     LiteralExponent,
+
+    #[token("NULL")]
+    LiteralNull,
 
     #[token("TRUE")]
     LiteralTrue,

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -230,6 +230,12 @@ pub enum Token {
     #[token("CONTINUE")]
     KeywordContinue,
 
+    #[token("POINTER")]
+    KeywordPointer,
+
+    #[token("REF_TO")]
+    KeywordRef,
+
     #[token("ARRAY")]
     KeywordArray,
 
@@ -276,6 +282,11 @@ pub enum Token {
 
     #[token(">=")]
     OperatorGreaterOrEqual,
+
+    #[token("&")]
+    OperatorAmp,
+    #[token("^")]
+    OperatorDeref,
 
     #[token("MOD")]
     OperatorModulo,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -535,7 +535,7 @@ fn parse_pointer_definition(
     lexer: &mut ParseSession,
     name: Option<String>,
 ) -> Option<(DataTypeDeclaration, Option<Statement>)> {
-    parse_type_reference_type_definition(lexer, None).map(|(decl, initializer)| {
+    parse_data_type_definition(lexer, None).map(|(decl, initializer)| {
         (
             DataTypeDeclaration::DataTypeDefinition {
                 data_type: DataType::PointerType {

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -254,6 +254,7 @@ fn parse_leaf_expression(lexer: &mut ParseSession) -> Statement {
         LiteralWideString => parse_literal_string(lexer, true),
         LiteralTrue => parse_bool_literal(lexer, true),
         LiteralFalse => parse_bool_literal(lexer, false),
+        LiteralNull => parse_null_literal(lexer),
         KeywordSquareParensOpen => parse_array_literal(lexer),
         _ => Err(Diagnostic::unexpected_token_found(
             "Literal".to_string(),
@@ -317,6 +318,17 @@ fn parse_bool_literal(lexer: &mut ParseSession, value: bool) -> Result<Statement
         value,
         location,
 
+        id: lexer.next_id(),
+    })
+}
+
+#[allow(clippy::unnecessary_wraps)]
+//Allowing the unnecessary wrap here because this method is used along other methods that need to return Results
+fn parse_null_literal(lexer: &mut ParseSession) -> Result<Statement, Diagnostic> {
+    let location = lexer.location();
+    lexer.advance();
+    Ok(Statement::LiteralNull {
+        location,
         id: lexer.next_id(),
     })
 }

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1026,6 +1026,31 @@ fn signed_literal_expression_test() {
 }"#;
     assert_eq!(ast_string, expected_ast);
 }
+
+#[test]
+fn assignment_to_null() {
+    let lexer = super::lex(
+        "
+        PROGRAM exp 
+        x := NULL;
+        END_PROGRAM
+        ",
+    );
+    let result = parse(lexer).0;
+
+    let prg = &result.implementations[0];
+    let statement = &prg.statements[0];
+
+    let ast_string = format!("{:#?}", statement);
+    let expected_ast = r#"Assignment {
+    left: Reference {
+        name: "x",
+    },
+    right: LiteralNull,
+}"#;
+    assert_eq!(ast_string, expected_ast);
+}
+
 #[test]
 fn pointer_address_test() {
     let lexer = super::lex(

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1026,6 +1026,98 @@ fn signed_literal_expression_test() {
 }"#;
     assert_eq!(ast_string, expected_ast);
 }
+#[test]
+fn pointer_address_test() {
+    let lexer = super::lex(
+        "
+        PROGRAM exp 
+        &x;
+        END_PROGRAM
+        ",
+    );
+    let result = parse(lexer).0;
+
+    let prg = &result.implementations[0];
+    let statement = &prg.statements[0];
+
+    let ast_string = format!("{:#?}", statement);
+    let expected_ast = r#"UnaryExpression {
+    operator: Address,
+    value: Reference {
+        name: "x",
+    },
+}"#;
+    assert_eq!(ast_string, expected_ast);
+}
+
+#[test]
+fn pointer_dereference_test() {
+    let lexer = super::lex(
+        "
+        PROGRAM exp 
+        x^;
+        END_PROGRAM
+        ",
+    );
+    let result = parse(lexer).0;
+
+    let prg = &result.implementations[0];
+    let statement = &prg.statements[0];
+
+    let ast_string = format!("{:#?}", statement);
+    let expected_ast = r#"PointerAccess {
+    reference: Reference {
+        name: "x",
+    },
+}"#;
+    assert_eq!(ast_string, expected_ast);
+}
+
+#[test]
+fn pointer_dereference_test_nested() {
+    let lexer = super::lex(
+        "
+        PROGRAM exp 
+        x^^[0][1]^[2]^^;
+        END_PROGRAM
+        ",
+    );
+    let result = parse(lexer).0;
+
+    let prg = &result.implementations[0];
+    let statement = &prg.statements[0];
+
+    let ast_string = format!("{:#?}", statement);
+    let expected_ast = r#"PointerAccess {
+    reference: PointerAccess {
+        reference: ArrayAccess {
+            reference: PointerAccess {
+                reference: ArrayAccess {
+                    reference: ArrayAccess {
+                        reference: PointerAccess {
+                            reference: PointerAccess {
+                                reference: Reference {
+                                    name: "x",
+                                },
+                            },
+                        },
+                        access: LiteralInteger {
+                            value: 0,
+                        },
+                    },
+                    access: LiteralInteger {
+                        value: 1,
+                    },
+                },
+            },
+            access: LiteralInteger {
+                value: 2,
+            },
+        },
+    },
+}"#;
+    assert_eq!(ast_string, expected_ast);
+}
 
 #[test]
 fn signed_literal_expression_reversed_test() {

--- a/src/parser/tests/misc_parser_tests.rs
+++ b/src/parser/tests/misc_parser_tests.rs
@@ -1,7 +1,8 @@
+// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+
 use core::panic;
 use std::ops::Range;
 
-// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::{
     ast::*,
     parser::{

--- a/src/parser/tests/type_parser_tests.rs
+++ b/src/parser/tests/type_parser_tests.rs
@@ -1,6 +1,7 @@
 use crate::{
     ast::*,
     parser::{parse, tests::lex, Statement::LiteralInteger},
+    Diagnostic,
 };
 use pretty_assertions::*;
 
@@ -290,4 +291,109 @@ fn struct_with_inline_array_can_be_parsed() {
     initializer: None,
 }"#;
     assert_eq!(ast_string, expected_ast);
+}
+
+#[test]
+fn pointer_type_test() {
+    let (result, diagnostics) = parse(lex(r#"
+        TYPE SamplePointer :
+            POINTER TO INT;
+        END_TYPE 
+        "#));
+    let pointer_type = &result.types[0];
+    let expected = UserTypeDeclaration {
+        data_type: DataType::PointerType {
+            name: Some("SamplePointer".into()),
+            referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
+                referenced_type: "INT".to_string(),
+            }),
+        },
+        initializer: None,
+    };
+    assert_eq!(
+        format!("{:#?}", expected),
+        format!("{:#?}", pointer_type).as_str()
+    );
+    assert_eq!(diagnostics.len(), 1);
+    let diagnostic = Diagnostic::ImprovementSuggestion {
+        message: "'POINTER TO' is not a standard keyword, use REF_TO instead".to_string(),
+        range: SourceRange::new(42..49),
+    };
+    assert_eq!(diagnostics[0], diagnostic);
+}
+
+#[test]
+fn ref_type_test() {
+    let (result, diagnostics) = parse(lex(r#"
+        TYPE SampleReference :
+            REF_TO INT;
+        END_TYPE 
+        "#));
+    let reference_type = &result.types[0];
+    let expected = UserTypeDeclaration {
+        data_type: DataType::PointerType {
+            name: Some("SampleReference".into()),
+            referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
+                referenced_type: "INT".to_string(),
+            }),
+        },
+        initializer: None,
+    };
+    assert_eq!(
+        format!("{:#?}", expected),
+        format!("{:#?}", reference_type).as_str()
+    );
+    assert_eq!(diagnostics.len(), 0)
+}
+
+#[test]
+fn global_pointer_declaration() {
+    let (result, diagnostics) = parse(lex(r#"
+        VAR_GLOBAL 
+            SampleReference : REF_TO INT;
+            SamplePointer : POINTER TO INT;
+        END_VAR 
+        "#));
+    let reference_type = &result.global_vars[0].variables[0];
+    let expected = Variable {
+        name: "SampleReference".into(),
+        data_type: DataTypeDeclaration::DataTypeDefinition {
+            data_type: DataType::PointerType {
+                name: None,
+                referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
+                    referenced_type: "INT".to_string(),
+                }),
+            },
+        },
+        initializer: None,
+        location: (0..0).into(),
+    };
+    assert_eq!(
+        format!("{:#?}", expected),
+        format!("{:#?}", reference_type).as_str()
+    );
+    let pointer_type = &result.global_vars[0].variables[1];
+    let expected = Variable {
+        name: "SamplePointer".into(),
+        data_type: DataTypeDeclaration::DataTypeDefinition {
+            data_type: DataType::PointerType {
+                name: None,
+                referenced_type: Box::new(DataTypeDeclaration::DataTypeReference {
+                    referenced_type: "INT".to_string(),
+                }),
+            },
+        },
+        initializer: None,
+        location: (0..0).into(),
+    };
+    assert_eq!(
+        format!("{:#?}", expected),
+        format!("{:#?}", pointer_type).as_str()
+    );
+    assert_eq!(diagnostics.len(), 1);
+    let diagnostic = Diagnostic::ImprovementSuggestion {
+        message: "'POINTER TO' is not a standard keyword, use REF_TO instead".to_string(),
+        range: SourceRange::new(91..98),
+    };
+    assert_eq!(diagnostics[0], diagnostic);
 }


### PR DESCRIPTION
Closes #177 

Add support for REF_TO and POINTER_TO
The types are interchangeable

TODO: 
- [x] Lexer
- [x] Parser
- [x] Indexing
- [ ] Annotations
- [ ] Codegen