### PR TITLE
Make codecov informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# https://docs.codecov.com/docs/common-recipe-list
+coverage:
+  status:
+    project:
+      default:
+        informational: true #Ignore failed coverage
+    patch:
+      default:
+        informational: true #Ignore failed coverage


### PR DESCRIPTION
Don't fail on code coverage report.

Taken from https://docs.codecov.com/docs/common-recipe-list
We can also keep it required but make it more forgiving