### PR TITLE
make annotations available in codegen

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -10,7 +10,7 @@ use self::{
     },
     llvm_index::LlvmTypedIndex,
 };
-use crate::compile_error::CompileError;
+use crate::{compile_error::CompileError, resolver::AnnotationMap};
 
 use super::ast::*;
 use super::index::*;
@@ -93,7 +93,8 @@ impl<'ink> CodeGen<'ink> {
     /// generates all TYPEs, GLOBAL-sections and POUs of the given CompilationUnit
     pub fn generate(
         &self,
-        unit: CompilationUnit,
+        unit: &CompilationUnit,
+        _annotations: &AnnotationMap,
         global_index: &Index,
     ) -> Result<String, CompileError> {
         //Associate the index type with LLVM types
@@ -103,10 +104,10 @@ impl<'ink> CodeGen<'ink> {
         let llvm = Llvm::new(self.context, self.context.create_builder());
         let pou_generator = PouGenerator::new(llvm, global_index, &llvm_index);
         //Generate the POU stubs in the first go to make sure they can be referenced.
-        for implementation in unit.implementations {
+        for implementation in &unit.implementations {
             //Don't generate external functions
             if implementation.linkage != LinkageType::External {
-                pou_generator.generate_implementation(&implementation)?;
+                pou_generator.generate_implementation(implementation)?;
             }
         }
         Ok(self.module.print_to_string().to_string())

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -12,8 +12,9 @@ macro_rules! codegen_wihout_unwrap {
         let context = inkwell::context::Context::create();
         crate::ast::pre_process(&mut ast);
         let index = crate::index::visitor::visit(&ast);
+        let annotations = crate::resolver::TypeAnnotator::visit_unit(&index, &ast);
         let code_generator = crate::codegen::CodeGen::new(&context, "main");
-        code_generator.generate(ast, &index)
+        code_generator.generate(&ast, &annotations, &index)
     }};
 }
 
@@ -26,8 +27,9 @@ macro_rules! codegen {
         let context = inkwell::context::Context::create();
         crate::ast::pre_process(&mut ast);
         let index = crate::index::visitor::visit(&ast);
+        let annotations = crate::resolver::TypeAnnotator::visit_unit(&index, &ast);
         let code_generator = crate::codegen::CodeGen::new(&context, "main");
-        code_generator.generate(ast, &index).unwrap()
+        code_generator.generate(&ast, &annotations, &index).unwrap()
     }};
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -177,6 +177,12 @@ impl AnnotationMap {
     }
 }
 
+impl Default for AnnotationMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'i> TypeAnnotator<'i> {
     /// constructs a new TypeAnnotater that works with the given index for type-lookups
     fn new(index: &'i Index) -> TypeAnnotator<'i> {


### PR DESCRIPTION
we dropped the idea of importing everything into one big
compilation unit. instead we now do multiple calls to the
generator - one for every parsed compilation unit.