### PR TITLE
introduce IdProvider using AtomicUsize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,12 @@ use inkwell::context::Context;
 use inkwell::targets::{
     CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine, TargetTriple,
 };
-use parser::ParsedAst;
-use resolver::TypeAnnotator;
+use lexer::IdProvider;
 use std::{fs::File, io::Read};
 use validation::Validator;
 
 use crate::ast::CompilationUnit;
-use crate::resolver::AnnotationMap;
+use crate::resolver::{AnnotationMap, TypeAnnotator};
 mod ast;
 pub mod cli;
 mod codegen;
@@ -447,6 +446,7 @@ pub fn compile_module<'c, T: SourceContainer>(
     encoding: Option<&'static Encoding>,
 ) -> Result<codegen::CodeGen<'c>, CompileError> {
     let mut full_index = Index::new();
+    let id_provider = IdProvider::new();
     let mut files: SimpleFiles<String, String> = SimpleFiles::new();
 
     let mut all_units = Vec::new();
@@ -460,7 +460,9 @@ pub fn compile_module<'c, T: SourceContainer>(
             .map_err(|err| CompileError::io_read_error(err, location.clone()))?;
         let file_id = files.add(location.clone(), e.source.clone());
 
-        let (mut parse_result, diagnostics) = parse(e.source.as_str());
+        let (mut parse_result, diagnostics) =
+            parser::parse(lexer::lex_with_ids(e.source.as_str(), id_provider.clone()));
+
         //pre-process the ast (create inlined types)
         ast::pre_process(&mut parse_result);
         //index the pou
@@ -523,11 +525,6 @@ fn report_diagnostics(
         })?;
     }
     Ok(())
-}
-
-fn parse(source: &str) -> ParsedAst {
-    let lexer = lexer::lex(source);
-    parser::parse(lexer)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
can generate unique Ids. Clones share a common
state to generate globally unique Ids (using Arc)

closes #281