### PR TITLE
arena implementation for const-expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -127,7 +133,7 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -144,6 +150,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generational-arena"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+dependencies = [
+ "cfg-if 0.1.10",
+]
 
 [[package]]
 name = "glob"
@@ -215,7 +230,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -346,7 +361,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -451,6 +466,7 @@ dependencies = [
  "codespan-reporting",
  "encoding_rs",
  "encoding_rs_io",
+ "generational-arena",
  "glob",
  "indexmap",
  "inkwell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ encoding_rs = "0.8"
 encoding_rs_io = "0.1"
 codespan-reporting = "0.11.1"
 mun_lld = "110.0.0"
-
+generational-arena = "0.2.8"
 
 [lib]
 name = "rusty"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::{Debug, Display, Formatter, Result},
     iter,
     ops::Range,
-    result, unimplemented,
+    unimplemented,
 };
 mod pre_processor;
 
@@ -1118,24 +1118,4 @@ pub fn flatten_expression_list(condition: &AstStatement) -> Vec<&AstStatement> {
 
 pub fn pre_process(unit: &mut CompilationUnit) {
     pre_processor::pre_process(unit)
-}
-
-/// extracts the compile-time value of the given statement.
-/// returns an error if no value can be derived at compile-time
-pub fn extract_value(s: &AstStatement) -> result::Result<String, String> {
-    match s {
-        AstStatement::UnaryExpression {
-            operator, value, ..
-        } => extract_value(value).map(|result| format!("{}{}", operator, result)),
-        AstStatement::LiteralInteger { value, .. } => Ok(value.to_string()),
-        //TODO constants
-        _ => Err("Unsupported Statement. Cannot evaluate expression.".to_string()),
-    }
-}
-
-/// evaluate the given statemetn as i128
-pub fn evaluate_constant_int(s: &AstStatement) -> result::Result<i128, String> {
-    //TODO give early return for literalInteger (I think the negative-number issue is solved now)
-    let value = extract_value(s);
-    value.map(|v| v.parse().unwrap_or(0))
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::{compile_error::CompileError, typesystem::DataTypeInformation};
+use crate::typesystem::DataTypeInformation;
 use std::{
     fmt::{Debug, Display, Formatter, Result},
     iter,
@@ -7,18 +7,6 @@ use std::{
     result, unimplemented,
 };
 mod pre_processor;
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Dimension {
-    pub start_offset: i32,
-    pub end_offset: i32,
-}
-
-impl Dimension {
-    pub fn get_length(&self) -> u32 {
-        (self.end_offset - self.start_offset + 1) as u32
-    }
-}
 
 pub type AstId = usize;
 
@@ -1132,52 +1120,22 @@ pub fn pre_process(unit: &mut CompilationUnit) {
     pre_processor::pre_process(unit)
 }
 
-/// constructs a vector with all dimensions for the given bounds-statement
-/// e.g. [0..10, 0..5]
-pub fn get_array_dimensions(bounds: &AstStatement) -> result::Result<Vec<Dimension>, CompileError> {
-    let mut result = vec![];
-    for statement in bounds.get_as_list() {
-        result.push(get_single_array_dimension(statement)?);
-    }
-    Ok(result)
-}
-
-/// constructs a Dimension for the given RangeStatement
-/// throws an error if the given statement is no RangeStatement
-fn get_single_array_dimension(bounds: &AstStatement) -> result::Result<Dimension, CompileError> {
-    if let AstStatement::RangeStatement { start, end, .. } = bounds {
-        let start_offset = evaluate_constant_int(start).unwrap_or(0);
-        let end_offset = evaluate_constant_int(end).unwrap_or(0);
-        Ok(Dimension {
-            start_offset,
-            end_offset,
-        })
-    } else {
-        Err(CompileError::codegen_error(
-            format!("Unexpected Statement {:?}, expected range", bounds),
-            bounds.get_location(),
-        ))
-    }
-}
-
 /// extracts the compile-time value of the given statement.
 /// returns an error if no value can be derived at compile-time
-fn extract_value(s: &AstStatement) -> result::Result<String, CompileError> {
+pub fn extract_value(s: &AstStatement) -> result::Result<String, String> {
     match s {
         AstStatement::UnaryExpression {
             operator, value, ..
         } => extract_value(value).map(|result| format!("{}{}", operator, result)),
         AstStatement::LiteralInteger { value, .. } => Ok(value.to_string()),
         //TODO constants
-        _ => Err(CompileError::codegen_error(
-            "Unsupported Statement. Cannot evaluate expression.".to_string(),
-            s.get_location(),
-        )),
+        _ => Err("Unsupported Statement. Cannot evaluate expression.".to_string()),
     }
 }
 
-/// evaluate the given statemetn as i32
-pub fn evaluate_constant_int(s: &AstStatement) -> result::Result<i32, CompileError> {
+/// evaluate the given statemetn as i128
+pub fn evaluate_constant_int(s: &AstStatement) -> result::Result<i128, String> {
+    //TODO give early return for literalInteger (I think the negative-number issue is solved now)
     let value = extract_value(s);
     value.map(|v| v.parse().unwrap_or(0))
 }

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -1,18 +1,15 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-
 /// the data_type_generator generates user defined data-types
 /// - Structures
 /// - Enum types
 /// - SubRange types
 /// - Alias types
 /// - sized Strings
+use crate::ast::SourceRange;
 use crate::index::{Index, VariableIndexEntry};
 use crate::resolver::AnnotationMap;
-use crate::{
-    ast::{AstStatement, Dimension},
-    compile_error::CompileError,
-    typesystem::DataTypeInformation,
-};
+use crate::typesystem::Dimension;
+use crate::{ast::AstStatement, compile_error::CompileError, typesystem::DataTypeInformation};
 use crate::{
     codegen::{
         llvm_index::LlvmTypedIndex,
@@ -25,6 +22,7 @@ use inkwell::{
     values::BasicValueEnum,
     AddressSpace,
 };
+use std::convert::TryFrom;
 
 use super::{
     expression_generator::ExpressionCodeGenerator, llvm::Llvm, struct_generator::StructGenerator,
@@ -135,10 +133,11 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
                         self.index.find_type(inner_type_name).unwrap(),
                     )
                     .unwrap();
-                let array_type = self
-                    .create_nested_array_type(inner_type, dimensions.clone())
-                    .into();
-                Ok(array_type)
+
+                self.create_nested_array_type(inner_type, dimensions.clone())
+                    .map(|it| it.as_basic_type_enum())
+                    .map_err(|err| CompileError::codegen_error(err, SourceRange::undefined()))
+                //TODO error location
             }
             DataTypeInformation::Integer { size, .. } => {
                 get_llvm_int_type(self.llvm.context, *size, name).map(|it| it.into())
@@ -150,12 +149,29 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
             DataTypeInformation::Float { size, .. } => {
                 get_llvm_float_type(self.llvm.context, *size, name).map(|it| it.into())
             }
-            DataTypeInformation::String { size, encoding } => Ok(self
-                .llvm
-                .context
-                .i8_type()
-                .array_type(*size * encoding.get_bytes_per_char())
-                .into()),
+            DataTypeInformation::String {
+                size,
+                default_size,
+                encoding,
+            } => {
+                let string_size = if let Some(size_expr) = size {
+                    //constant expression
+                    self.index
+                        .get_constant_int_expression(size_expr)
+                        .and_then(|s| u32::try_from(s).map_err(|err| format!("{:}", err)))
+                        .map_err(|err| CompileError::codegen_error(err, SourceRange::undefined()))?
+                //TODO error location
+                } else {
+                    //default size
+                    *default_size
+                };
+                Ok(self
+                    .llvm
+                    .context
+                    .i8_type()
+                    .array_type(string_size * encoding.get_bytes_per_char())
+                    .into())
+            }
             DataTypeInformation::SubRange {
                 referenced_type, ..
             } => {
@@ -227,7 +243,10 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
         data_type: &DataType,
         referenced_type: &str,
     ) -> Option<BasicValueEnum<'ink>> {
-        if let Some(initializer) = self.index.get_constant_expression(&data_type.initial_value) {
+        if let Some(initializer) = self
+            .index
+            .get_maybe_constant_expression(&data_type.initial_value)
+        {
             let generator = ExpressionCodeGenerator::new_context_free(
                 self.llvm,
                 self.index,
@@ -254,7 +273,10 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
         predicate: fn(&AstStatement) -> bool,
         expected_ast: &str,
     ) -> Result<Option<BasicValueEnum<'ink>>, CompileError> {
-        if let Some(initializer) = self.index.get_constant_expression(&data_type.initial_value) {
+        if let Some(initializer) = self
+            .index
+            .get_maybe_constant_expression(&data_type.initial_value)
+        {
             if predicate(initializer) {
                 let array_type = self.index.get_type_information(name)?;
                 let generator = ExpressionCodeGenerator::new_context_free(
@@ -282,32 +304,22 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
         &self,
         end_type: BasicTypeEnum<'ink>,
         dimensions: Vec<Dimension>,
-    ) -> ArrayType<'ink> {
+    ) -> Result<ArrayType<'ink>, String> {
         let mut result: Option<ArrayType> = None;
         let mut current_type = end_type;
+
         for dimension in dimensions.iter().rev() {
+            let len = dimension.get_length(self.index)?;
             result = Some(match current_type {
-                BasicTypeEnum::IntType(..) => current_type
-                    .into_int_type()
-                    .array_type(dimension.get_length()),
-                BasicTypeEnum::FloatType(..) => current_type
-                    .into_float_type()
-                    .array_type(dimension.get_length()),
-                BasicTypeEnum::StructType(..) => current_type
-                    .into_struct_type()
-                    .array_type(dimension.get_length()),
-                BasicTypeEnum::ArrayType(..) => current_type
-                    .into_array_type()
-                    .array_type(dimension.get_length()),
-                BasicTypeEnum::PointerType(..) => current_type
-                    .into_pointer_type()
-                    .array_type(dimension.get_length()),
-                BasicTypeEnum::VectorType(..) => current_type
-                    .into_vector_type()
-                    .array_type(dimension.get_length()),
+                BasicTypeEnum::IntType(..) => current_type.into_int_type().array_type(len),
+                BasicTypeEnum::FloatType(..) => current_type.into_float_type().array_type(len),
+                BasicTypeEnum::StructType(..) => current_type.into_struct_type().array_type(len),
+                BasicTypeEnum::ArrayType(..) => current_type.into_array_type().array_type(len),
+                BasicTypeEnum::PointerType(..) => current_type.into_pointer_type().array_type(len),
+                BasicTypeEnum::VectorType(..) => current_type.into_vector_type().array_type(len),
             });
             current_type = result.unwrap().into();
         }
-        result.unwrap()
+        Ok(result.unwrap())
     }
 }

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -227,7 +227,7 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
         data_type: &DataType,
         referenced_type: &str,
     ) -> Option<BasicValueEnum<'ink>> {
-        if let Some(initializer) = &data_type.initial_value {
+        if let Some(initializer) = self.index.get_constant_expression(&data_type.initial_value) {
             let generator = ExpressionCodeGenerator::new_context_free(
                 self.llvm,
                 self.index,
@@ -254,7 +254,7 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
         predicate: fn(&AstStatement) -> bool,
         expected_ast: &str,
     ) -> Result<Option<BasicValueEnum<'ink>>, CompileError> {
-        if let Some(initializer) = &data_type.initial_value {
+        if let Some(initializer) = self.index.get_constant_expression(&data_type.initial_value) {
             if predicate(initializer) {
                 let array_type = self.index.get_type_information(name)?;
                 let generator = ExpressionCodeGenerator::new_context_free(

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -233,7 +233,7 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
     ) -> Option<BasicValueEnum<'ink>> {
         if let Some(initializer) = self
             .index
-            .get_maybe_constant_expression(&data_type.initial_value)
+            .maybe_get_constant_expression(&data_type.initial_value)
         {
             let generator = ExpressionCodeGenerator::new_context_free(
                 self.llvm,
@@ -263,7 +263,7 @@ impl<'ink, 'b> DataTypeGenerator<'ink, 'b> {
     ) -> Result<Option<BasicValueEnum<'ink>>, CompileError> {
         if let Some(initializer) = self
             .index
-            .get_maybe_constant_expression(&data_type.initial_value)
+            .maybe_get_constant_expression(&data_type.initial_value)
         {
             if predicate(initializer) {
                 let array_type = self.index.get_type_information(name)?;

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -944,17 +944,17 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
         dimension: &Dimension,
         access_expression: &AstStatement,
     ) -> Result<IntValue<'a>, CompileError> {
-        let start_offset = self
-            .index
-            .get_constant_int_expression(&dimension.start_offset)
-            .map_err(|err| CompileError::codegen_error(err, access_expression.get_location()))?;
+        let start_offset = dimension
+            .start_offset
+            .as_int_value(self.index)
+            .map_err(|it| CompileError::codegen_error(it, access_expression.get_location()))?;
 
         let (_, access_value) = self.generate_expression(access_expression)?;
         //If start offset is not 0, adjust the current statement with an add operation
         if start_offset != 0 {
             Ok(self.llvm.builder.build_int_sub(
                 access_value.into_int_value(),
-                self.llvm.i32_type().const_int(start_offset as u64, true),
+                self.llvm.i32_type().const_int(start_offset as u64, true), //TODO error handling for cast
                 "",
             ))
         } else {

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -285,7 +285,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
                 location: variable.source_location.clone(),
                 id: 0, //TODO
             };
-            let right = variable.initial_value.as_ref().unwrap();
+            let right = self.index.get_constant_expression(&variable.initial_value).unwrap();
             statement_generator.generate_assignment_statement(&left, right)?;
         }
         Ok(())

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -285,7 +285,10 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
                 location: variable.source_location.clone(),
                 id: 0, //TODO
             };
-            let right = self.index.get_constant_expression(&variable.initial_value).unwrap();
+            let right = self
+                .index
+                .get_maybe_constant_expression(&variable.initial_value)
+                .unwrap();
             statement_generator.generate_assignment_statement(&left, right)?;
         }
         Ok(())

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -287,7 +287,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
             };
             let right = self
                 .index
-                .get_maybe_constant_expression(&variable.initial_value)
+                .maybe_get_constant_expression(&variable.initial_value)
                 .unwrap();
             statement_generator.generate_assignment_statement(&left, right)?;
         }

--- a/src/codegen/generators/struct_generator.rs
+++ b/src/codegen/generators/struct_generator.rs
@@ -102,7 +102,7 @@ impl<'a, 'b> StructGenerator<'a, 'b> {
         let variable_type = self.index.get_type_information(type_name)?;
         let initializer = match self
             .index
-            .get_maybe_constant_expression(&variable.initial_value)
+            .maybe_get_constant_expression(&variable.initial_value)
         {
             Some(statement) => {
                 let exp_gen = ExpressionCodeGenerator::new_context_free(

--- a/src/codegen/generators/struct_generator.rs
+++ b/src/codegen/generators/struct_generator.rs
@@ -100,7 +100,10 @@ impl<'a, 'b> StructGenerator<'a, 'b> {
         //                         //&variable.data_type.get_name().ok_or_else(|| error_type_not_associated(type_name, &variable.location))?;
 
         let variable_type = self.index.get_type_information(type_name)?;
-        let initializer = match self.index.get_constant_expression(&variable.initial_value) {
+        let initializer = match self
+            .index
+            .get_maybe_constant_expression(&variable.initial_value)
+        {
             Some(statement) => {
                 let exp_gen = ExpressionCodeGenerator::new_context_free(
                     self.llvm,

--- a/src/codegen/generators/struct_generator.rs
+++ b/src/codegen/generators/struct_generator.rs
@@ -100,7 +100,7 @@ impl<'a, 'b> StructGenerator<'a, 'b> {
         //                         //&variable.data_type.get_name().ok_or_else(|| error_type_not_associated(type_name, &variable.location))?;
 
         let variable_type = self.index.get_type_information(type_name)?;
-        let initializer = match &variable.initial_value {
+        let initializer = match self.index.get_constant_expression(&variable.initial_value) {
             Some(statement) => {
                 let exp_gen = ExpressionCodeGenerator::new_context_free(
                     self.llvm,

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -51,7 +51,9 @@ pub fn generate_global_variable<'ctx, 'b>(
     let type_name = global_variable.get_type_name();
     let variable_type = index.get_associated_type(type_name)?;
 
-    let initial_value = if let Some(initializer) = global_index.get_constant_expression(&global_variable.initial_value) {
+    let initial_value = if let Some(initializer) =
+        global_index.get_maybe_constant_expression(&global_variable.initial_value)
+    {
         let expr_generator = ExpressionCodeGenerator::new_context_free(
             llvm,
             global_index,

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -52,7 +52,7 @@ pub fn generate_global_variable<'ctx, 'b>(
     let variable_type = index.get_associated_type(type_name)?;
 
     let initial_value = if let Some(initializer) =
-        global_index.get_maybe_constant_expression(&global_variable.initial_value)
+        global_index.maybe_get_constant_expression(&global_variable.initial_value)
     {
         let expr_generator = ExpressionCodeGenerator::new_context_free(
             llvm,

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -51,7 +51,7 @@ pub fn generate_global_variable<'ctx, 'b>(
     let type_name = global_variable.get_type_name();
     let variable_type = index.get_associated_type(type_name)?;
 
-    let initial_value = if let Some(initializer) = &global_variable.initial_value {
+    let initial_value = if let Some(initializer) = global_index.get_constant_expression(&global_variable.initial_value) {
         let expr_generator = ExpressionCodeGenerator::new_context_free(
             llvm,
             global_index,

--- a/src/index.rs
+++ b/src/index.rs
@@ -664,13 +664,17 @@ impl Index {
     }
 
     /// convinience-method to add the constant exression if there is some, otherwhise not
-    pub fn add_maybe_constant_expression(&mut self, expr: Option<AstStatement>) -> Option<ConstId> {
+    /// use this only as a shortcut if you have an Option<AstStatement> - e.g. an optional initializer.
+    /// otherwhise use `add_constant_expression`
+    pub fn maybe_add_constant_expression(&mut self, expr: Option<AstStatement>) -> Option<ConstId> {
         expr.map(|it| self.add_constant_expression(it))
     }
 
     /// convinience-method to query for an optional constant expression.
     /// if the given `id` is `None`, this method returns `None`
-    pub fn get_maybe_constant_expression(&self, id: &Option<ConstId>) -> Option<&AstStatement> {
+    /// use this only as a shortcut if you have an Option<ConstId> - e.g. an optional initializer.
+    /// otherwhise use `get_constant_expression`
+    pub fn maybe_get_constant_expression(&self, id: &Option<ConstId>) -> Option<&AstStatement> {
         id.as_ref().and_then(|it| self.get_constant_expression(it))
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,7 +2,7 @@
 use indexmap::IndexMap;
 
 use crate::{
-    ast::{evaluate_constant_int, AstStatement, Implementation, PouType, SourceRange},
+    ast::{AstStatement, Implementation, PouType, SourceRange},
     compile_error::CompileError,
     typesystem::*,
 };
@@ -689,7 +689,10 @@ impl Index {
     pub fn get_constant_int_expression(&self, id: &ConstId) -> Result<i128, String> {
         self.get_constant_expression(id)
             .ok_or_else(|| "Cannot find constant expression".into())
-            .and_then(|it| evaluate_constant_int(it))
+            .and_then(|it| match it {
+                AstStatement::LiteralInteger { value, .. } => Ok(*value),
+                _ => Err(format!("Cannot extract int constant from {:#?}", it)),
+            })
     }
 }
 

--- a/src/index/const_expressions.rs
+++ b/src/index/const_expressions.rs
@@ -1,0 +1,35 @@
+use generational_arena::Arena;
+
+use crate::ast::AstStatement;
+
+// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+
+pub type ConstId = generational_arena::Index;
+pub struct ConstExpressions{
+    expressions: Arena::<AstStatement>,
+}
+
+impl ConstExpressions {
+    pub fn new() -> ConstExpressions {
+        ConstExpressions {
+            expressions: Arena::new(),
+        }
+    }
+
+    pub fn add_expression(&mut self, statement: AstStatement) -> ConstId {
+        self.expressions.insert(statement)
+    }
+
+    pub fn add_maybe(&mut self, statement: &Option<AstStatement>) -> Option<ConstId> {
+        statement.as_ref().map(|it| self.add_expression(it.clone()))
+    }
+
+    pub fn find_expression(&self, id: &ConstId) -> Option<&AstStatement> {
+        self.expressions.get(*id)
+    }
+
+    pub fn remove(&mut self, id: &ConstId) -> Option<AstStatement> {
+        self.expressions.remove(*id)
+    }
+}
+

--- a/src/index/const_expressions.rs
+++ b/src/index/const_expressions.rs
@@ -1,8 +1,7 @@
-use generational_arena::Arena;
+// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
 use crate::ast::AstStatement;
-
-// Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use generational_arena::Arena;
 
 pub type ConstId = generational_arena::Index;
 pub struct ConstExpressions {

--- a/src/index/const_expressions.rs
+++ b/src/index/const_expressions.rs
@@ -5,8 +5,8 @@ use crate::ast::AstStatement;
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
 pub type ConstId = generational_arena::Index;
-pub struct ConstExpressions{
-    expressions: Arena::<AstStatement>,
+pub struct ConstExpressions {
+    expressions: Arena<AstStatement>,
 }
 
 impl ConstExpressions {
@@ -33,3 +33,8 @@ impl ConstExpressions {
     }
 }
 
+impl Default for ConstExpressions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/index/const_expressions.rs
+++ b/src/index/const_expressions.rs
@@ -4,6 +4,8 @@ use crate::ast::AstStatement;
 use generational_arena::Arena;
 
 pub type ConstId = generational_arena::Index;
+
+#[derive(Default)]
 pub struct ConstExpressions {
     expressions: Arena<AstStatement>,
 }
@@ -19,21 +21,11 @@ impl ConstExpressions {
         self.expressions.insert(statement)
     }
 
-    pub fn add_maybe(&mut self, statement: &Option<AstStatement>) -> Option<ConstId> {
-        statement.as_ref().map(|it| self.add_expression(it.clone()))
-    }
-
     pub fn find_expression(&self, id: &ConstId) -> Option<&AstStatement> {
         self.expressions.get(*id)
     }
 
     pub fn remove(&mut self, id: &ConstId) -> Option<AstStatement> {
         self.expressions.remove(*id)
-    }
-}
-
-impl Default for ConstExpressions {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -1342,17 +1342,17 @@ fn global_initializers_are_stored_in_the_const_expression_arena() {
     let variables = &ast.global_vars[0].variables;
     let initializer = index
         .find_global_variable("a")
-        .and_then(|g| index.get_maybe_constant_expression(&g.initial_value));
+        .and_then(|g| index.maybe_get_constant_expression(&g.initial_value));
     assert_eq!(variables[0].initializer.as_ref(), initializer);
 
     let initializer = index
         .find_global_variable("b")
-        .and_then(|g| index.get_maybe_constant_expression(&g.initial_value));
+        .and_then(|g| index.maybe_get_constant_expression(&g.initial_value));
     assert_eq!(variables[1].initializer.as_ref(), initializer);
 
     let initializer = index
         .find_global_variable("c")
-        .and_then(|g| index.get_maybe_constant_expression(&g.initial_value));
+        .and_then(|g| index.maybe_get_constant_expression(&g.initial_value));
     assert_eq!(variables[2].initializer.as_ref(), initializer);
 }
 
@@ -1379,17 +1379,17 @@ fn local_initializers_are_stored_in_the_const_expression_arena() {
     let variables = &ast.units[0].variable_blocks[0].variables;
     let initializer = index
         .find_member("prg", "a")
-        .and_then(|g| index.get_maybe_constant_expression(&g.initial_value));
+        .and_then(|g| index.maybe_get_constant_expression(&g.initial_value));
     assert_eq!(variables[0].initializer.as_ref(), initializer);
 
     let initializer = index
         .find_member("prg", "b")
-        .and_then(|g| index.get_maybe_constant_expression(&g.initial_value));
+        .and_then(|g| index.maybe_get_constant_expression(&g.initial_value));
     assert_eq!(variables[1].initializer.as_ref(), initializer);
 
     let initializer = index
         .find_member("prg", "c")
-        .and_then(|g| index.get_maybe_constant_expression(&g.initial_value));
+        .and_then(|g| index.maybe_get_constant_expression(&g.initial_value));
     assert_eq!(variables[2].initializer.as_ref(), initializer);
 }
 
@@ -1410,7 +1410,7 @@ fn datatype_initializers_are_stored_in_the_const_expression_arena() {
     let data_type = &ast.types[0];
     let initializer = index
         .find_type("MyInt")
-        .and_then(|g| index.get_maybe_constant_expression(&g.initial_value));
+        .and_then(|g| index.maybe_get_constant_expression(&g.initial_value));
     assert_eq!(data_type.initializer.as_ref(), initializer);
 }
 
@@ -1498,7 +1498,7 @@ fn array_dimensions_are_stored_in_the_const_expression_arena() {
 fn string_dimensions_are_stored_in_the_const_expression_arena() {
     // GIVEN a string type with a const expression as length
     let src = "
-        TYPE MyString : STRING(LEN-1);
+        TYPE MyString : STRING[LEN-1];
         ";
     // WHEN the program is indexed
     let (mut ast, ..) = crate::parser::parse(crate::lexer::lex(src));

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -86,7 +86,7 @@ pub fn visit_pou(index: &mut Index, pou: &Pou) {
                 var.data_type.get_name().unwrap().to_string()
             };
 
-            let initial_value = index.add_maybe_constant_expression(var.initializer.clone());
+            let initial_value = index.maybe_add_constant_expression(var.initializer.clone());
 
             index.register_member_variable(
                 &MemberInfo {
@@ -173,7 +173,7 @@ fn register_inout_pointer_type_for(index: &mut Index, var: &Variable) -> String 
 
 fn visit_global_var_block(index: &mut Index, block: &VariableBlock) {
     for var in &block.variables {
-        let initializer = index.add_maybe_constant_expression(var.initializer.clone());
+        let initializer = index.maybe_add_constant_expression(var.initializer.clone());
         index.register_global_variable(
             &var.name,
             var.data_type.get_name().unwrap(),
@@ -210,7 +210,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 varargs: None,
             };
 
-            let init = index.add_maybe_constant_expression(type_declatation.initializer.clone());
+            let init = index.maybe_add_constant_expression(type_declatation.initializer.clone());
             index.register_type(name.as_ref().unwrap(), init, information);
             for (count, var) in variables.iter().enumerate() {
                 if let DataTypeDeclaration::DataTypeDefinition { data_type, .. } = &var.data_type {
@@ -225,7 +225,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                     )
                 }
 
-                let init = index.add_maybe_constant_expression(var.initializer.clone());
+                let init = index.maybe_add_constant_expression(var.initializer.clone());
                 index.register_member_variable(
                     &MemberInfo {
                         container_name: struct_name,
@@ -247,7 +247,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 elements: elements.clone(),
             };
 
-            let init = index.add_maybe_constant_expression(type_declatation.initializer.clone());
+            let init = index.maybe_add_constant_expression(type_declatation.initializer.clone());
             index.register_type(enum_name.as_str(), init, information);
 
             elements.iter().enumerate().for_each(|(i, v)| {
@@ -284,7 +284,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 }
             };
 
-            let init = index.add_maybe_constant_expression(type_declatation.initializer.clone());
+            let init = index.maybe_add_constant_expression(type_declatation.initializer.clone());
             index.register_type(name.as_ref().unwrap(), init, information)
         }
         DataType::ArrayType {
@@ -321,7 +321,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 dimensions,
             };
 
-            let init = index.add_maybe_constant_expression(type_declatation.initializer.clone());
+            let init = index.maybe_add_constant_expression(type_declatation.initializer.clone());
             index.register_type(name.as_ref().unwrap(), init, information)
         }
         DataType::PointerType {
@@ -336,7 +336,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 auto_deref: false,
             };
 
-            let init = index.add_maybe_constant_expression(type_declatation.initializer.clone());
+            let init = index.maybe_add_constant_expression(type_declatation.initializer.clone());
             index.register_type(name.as_ref().unwrap(), init, information)
         }
         DataType::StringType {
@@ -373,7 +373,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 None => TypeSize::from_literal(DEFAULT_STRING_LEN + 1),
             };
             let information = DataTypeInformation::String { size, encoding };
-            let init = index.add_maybe_constant_expression(type_declatation.initializer.clone());
+            let init = index.maybe_add_constant_expression(type_declatation.initializer.clone());
             index.register_type(name.as_ref().unwrap(), init, information)
         }
         DataType::VarArgs { .. } => {} //Varargs are not indexed

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ mod control_parser;
 mod expressions_parser;
 
 #[cfg(test)]
-mod tests;
+pub mod tests;
 pub type ParsedAst = (CompilationUnit, Vec<Diagnostic>);
 
 pub fn parse(mut lexer: ParseSession) -> ParsedAst {

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -1,10 +1,8 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use std::ops::Range;
 
-use crate::{
-    ast::{AstStatement, Dimension},
-    index::Index,
-};
+
+use crate::{ast::{AstStatement, Dimension}, index::{Index, const_expressions::{ConstId}}};
 
 pub const DEFAULT_STRING_LEN: u32 = 80;
 
@@ -48,7 +46,7 @@ pub const VOID_TYPE: &str = "VOID";
 pub struct DataType {
     pub name: String,
     /// the initial value defined on the TYPE-declration
-    pub initial_value: Option<AstStatement>,
+    pub initial_value: Option<ConstId>,
     pub information: DataTypeInformation,
     //TODO : Add location information
 }


### PR DESCRIPTION
const expressions are no longer stored directly in the index
but they are stored in an arena. This way it is easier to
replace them later when we want to resolve the expressions
into literals.

~~dedicated ConstExpressions-Tests still missing~~