### PR TITLE
Make compile and run return a generic type

### DIFF
--- a/tests/correctness/arrays.rs
+++ b/tests/correctness/arrays.rs
@@ -41,7 +41,7 @@ fn array_assignments() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
 
     for index in 0..5 {
         assert_eq!((index + 10) as i16, maintype.int_array[index]);
@@ -70,7 +70,7 @@ fn matrix_array_assignments() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -100,7 +100,7 @@ fn matrix_array_assignments2() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -133,7 +133,7 @@ fn cube_array_assignments_array_of_array_of_array() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {
@@ -168,7 +168,7 @@ fn cube_array_assignments2() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {

--- a/tests/correctness/arrays.rs
+++ b/tests/correctness/arrays.rs
@@ -41,7 +41,7 @@ fn array_assignments() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
 
     for index in 0..5 {
         assert_eq!((index + 10) as i16, maintype.int_array[index]);
@@ -70,7 +70,7 @@ fn matrix_array_assignments() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -100,7 +100,7 @@ fn matrix_array_assignments2() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -133,7 +133,7 @@ fn cube_array_assignments_array_of_array_of_array() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {
@@ -168,7 +168,7 @@ fn cube_array_assignments2() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {

--- a/tests/correctness/arrays.rs
+++ b/tests/correctness/arrays.rs
@@ -41,7 +41,7 @@ fn array_assignments() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
 
     for index in 0..5 {
         assert_eq!((index + 10) as i16, maintype.int_array[index]);
@@ -70,7 +70,7 @@ fn matrix_array_assignments() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -100,7 +100,7 @@ fn matrix_array_assignments2() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -133,7 +133,7 @@ fn cube_array_assignments_array_of_array_of_array() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {
@@ -168,7 +168,7 @@ fn cube_array_assignments2() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {

--- a/tests/correctness/bitaccess.rs
+++ b/tests/correctness/bitaccess.rs
@@ -38,7 +38,7 @@ fn bitaccess_test() {
     ";
     let mut main_type = MainType::default();
 
-    compile_and_run(prog.to_string(), &mut main_type);
+    compile_and_run::<_,i32>(prog.to_string(), &mut main_type);
     assert_eq!(
         main_type,
         MainType {
@@ -81,7 +81,7 @@ fn bitaccess_with_var_test() {
     ";
     let mut main_type = MainType::default();
 
-    compile_and_run(prog.to_string(), &mut main_type);
+    compile_and_run::<_,i32>(prog.to_string(), &mut main_type);
     assert_eq!(
         main_type,
         MainType {

--- a/tests/correctness/bitaccess.rs
+++ b/tests/correctness/bitaccess.rs
@@ -38,7 +38,7 @@ fn bitaccess_test() {
     ";
     let mut main_type = MainType::default();
 
-    compile_and_run::<_,i32>(prog.to_string(), &mut main_type);
+    compile_and_run::<_, i32>(prog.to_string(), &mut main_type);
     assert_eq!(
         main_type,
         MainType {
@@ -81,7 +81,7 @@ fn bitaccess_with_var_test() {
     ";
     let mut main_type = MainType::default();
 
-    compile_and_run::<_,i32>(prog.to_string(), &mut main_type);
+    compile_and_run::<_, i32>(prog.to_string(), &mut main_type);
     assert_eq!(
         main_type,
         MainType {

--- a/tests/correctness/classes.rs
+++ b/tests/correctness/classes.rs
@@ -49,7 +49,7 @@ fn class_reference_in_pou() {
         "
     .into();
 
-    let res : i32 = compile_and_run(
+    let res: i32 = compile_and_run(
         source,
         &mut MainType {
             cl: MyClass { x: 0, y: 0 },

--- a/tests/correctness/classes.rs
+++ b/tests/correctness/classes.rs
@@ -49,7 +49,7 @@ fn class_reference_in_pou() {
         "
     .into();
 
-    let (res, _) = compile_and_run(
+    let (res, _) = compile_and_run_i32(
         source,
         &mut MainType {
             cl: MyClass { x: 0, y: 0 },

--- a/tests/correctness/classes.rs
+++ b/tests/correctness/classes.rs
@@ -49,7 +49,7 @@ fn class_reference_in_pou() {
         "
     .into();
 
-    let (res, _) = compile_and_run_i32(
+    let res : i32 = compile_and_run(
         source,
         &mut MainType {
             cl: MyClass { x: 0, y: 0 },

--- a/tests/correctness/control_flow.rs
+++ b/tests/correctness/control_flow.rs
@@ -46,7 +46,7 @@ fn adding_through_conditions() {
 
     let (func_true, func_false) = function;
 
-    let (res, _) = compile_and_run(
+    let (res, _) = compile_and_run_i32(
         func_true,
         &mut MainType {
             inc: 0,
@@ -55,7 +55,7 @@ fn adding_through_conditions() {
         },
     );
     assert_eq!(res, 10);
-    let (res, _) = compile_and_run(
+    let (res, _) = compile_and_run_i32(
         func_false,
         &mut MainType {
             inc: 0,
@@ -94,9 +94,9 @@ fn adding_through_conditions_to_function_return() {
 
     let (func_true, func_false) = function;
 
-    let (res, _) = compile_and_run(func_true, &mut MainType { ret: 0 });
+    let (res, _) = compile_and_run_i32(func_true, &mut MainType { ret: 0 });
     assert_eq!(res, 10);
-    let (res, _) = compile_and_run(func_false, &mut MainType { ret: 0 });
+    let (res, _) = compile_and_run_i32(func_false, &mut MainType { ret: 0 });
     assert_eq!(res, 100);
 }
 
@@ -116,7 +116,7 @@ fn early_return_test() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 100);
 }
 
@@ -138,7 +138,7 @@ fn for_continue_test() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 11);
 }
 
@@ -161,7 +161,7 @@ fn while_continue_test() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 10);
 }
 
@@ -186,7 +186,7 @@ fn loop_exit_test() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 100);
 }
 
@@ -211,7 +211,7 @@ fn for_loop_and_increment_10_times() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 110);
 }
 
@@ -235,7 +235,7 @@ fn for_loop_and_increment_10_times_skipping_1() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 1005);
 }
 
@@ -263,7 +263,7 @@ fn while_loop_no_entry() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 5);
 }
 
@@ -292,7 +292,7 @@ fn exit_in_if_in_while_loop() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 10);
 }
 
@@ -321,7 +321,7 @@ fn exit_in_for_loop_in_while_loop() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 20);
 }
 
@@ -351,7 +351,7 @@ fn continue_in_for_loop_in_while_loop() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 31);
 }
 
@@ -380,7 +380,7 @@ fn repeat_loop_no_entry() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 1017);
 }
 #[test]
@@ -406,7 +406,7 @@ fn while_loop_10_times() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 10101);
 }
 
@@ -434,7 +434,7 @@ fn repeat_loop_10_times() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 10101);
 }
 
@@ -462,20 +462,20 @@ fn case_statement() {
     "#;
 
     (1..9).for_each(|i| {
-        let (res, _) = compile_and_run(function.to_string(), &mut MainType { i });
+        let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i });
         assert_eq!(res, 101);
     });
 
     (10..19).for_each(|i| {
-        let (res, _) = compile_and_run(function.to_string(), &mut MainType { i });
+        let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i });
         assert_eq!(res, 201);
     });
 
     (20..29).for_each(|i| {
-        let (res, _) = compile_and_run(function.to_string(), &mut MainType { i });
+        let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i });
         assert_eq!(res, 301);
     });
 
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { i: 999 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 999 });
     assert_eq!(res, 7);
 }

--- a/tests/correctness/control_flow.rs
+++ b/tests/correctness/control_flow.rs
@@ -46,7 +46,7 @@ fn adding_through_conditions() {
 
     let (func_true, func_false) = function;
 
-    let (res, _) = compile_and_run_i32(
+    let res : i32 = compile_and_run(
         func_true,
         &mut MainType {
             inc: 0,
@@ -55,7 +55,7 @@ fn adding_through_conditions() {
         },
     );
     assert_eq!(res, 10);
-    let (res, _) = compile_and_run_i32(
+    let res : i32 = compile_and_run(
         func_false,
         &mut MainType {
             inc: 0,
@@ -94,9 +94,9 @@ fn adding_through_conditions_to_function_return() {
 
     let (func_true, func_false) = function;
 
-    let (res, _) = compile_and_run_i32(func_true, &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(func_true, &mut MainType { ret: 0 });
     assert_eq!(res, 10);
-    let (res, _) = compile_and_run_i32(func_false, &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(func_false, &mut MainType { ret: 0 });
     assert_eq!(res, 100);
 }
 
@@ -116,7 +116,7 @@ fn early_return_test() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 100);
 }
 
@@ -138,7 +138,7 @@ fn for_continue_test() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 11);
 }
 
@@ -161,7 +161,7 @@ fn while_continue_test() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 10);
 }
 
@@ -186,7 +186,7 @@ fn loop_exit_test() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 100);
 }
 
@@ -211,7 +211,7 @@ fn for_loop_and_increment_10_times() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 110);
 }
 
@@ -235,7 +235,7 @@ fn for_loop_and_increment_10_times_skipping_1() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 1005);
 }
 
@@ -263,7 +263,7 @@ fn while_loop_no_entry() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 5);
 }
 
@@ -292,7 +292,7 @@ fn exit_in_if_in_while_loop() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 10);
 }
 
@@ -321,7 +321,7 @@ fn exit_in_for_loop_in_while_loop() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 20);
 }
 
@@ -351,7 +351,7 @@ fn continue_in_for_loop_in_while_loop() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 31);
 }
 
@@ -380,7 +380,7 @@ fn repeat_loop_no_entry() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 1017);
 }
 #[test]
@@ -406,7 +406,7 @@ fn while_loop_10_times() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 10101);
 }
 
@@ -434,7 +434,7 @@ fn repeat_loop_10_times() {
     END_FUNCTION
     "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 0, ret: 0 });
     assert_eq!(res, 10101);
 }
 
@@ -462,20 +462,20 @@ fn case_statement() {
     "#;
 
     (1..9).for_each(|i| {
-        let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i });
+        let res: i32 = compile_and_run(function.to_string(), &mut MainType { i });
         assert_eq!(res, 101);
     });
 
     (10..19).for_each(|i| {
-        let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i });
+        let res: i32 = compile_and_run(function.to_string(), &mut MainType { i });
         assert_eq!(res, 201);
     });
 
     (20..29).for_each(|i| {
-        let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i });
+        let res: i32 = compile_and_run(function.to_string(), &mut MainType { i });
         assert_eq!(res, 301);
     });
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { i: 999 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { i: 999 });
     assert_eq!(res, 7);
 }

--- a/tests/correctness/control_flow.rs
+++ b/tests/correctness/control_flow.rs
@@ -46,7 +46,7 @@ fn adding_through_conditions() {
 
     let (func_true, func_false) = function;
 
-    let res : i32 = compile_and_run(
+    let res: i32 = compile_and_run(
         func_true,
         &mut MainType {
             inc: 0,
@@ -55,7 +55,7 @@ fn adding_through_conditions() {
         },
     );
     assert_eq!(res, 10);
-    let res : i32 = compile_and_run(
+    let res: i32 = compile_and_run(
         func_false,
         &mut MainType {
             inc: 0,

--- a/tests/correctness/custom_datatypes.rs
+++ b/tests/correctness/custom_datatypes.rs
@@ -43,7 +43,7 @@ fn using_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run(testcode.to_string(), &mut main_data);
+    compile_and_run_i32(testcode.to_string(), &mut main_data);
     assert_eq!(3, main_data.my_s.field1);
     assert_eq!(7, main_data.my_s.field2);
     assert_eq!(10, main_data.my_s.field3);
@@ -129,7 +129,7 @@ fn using_nested_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run(testcode.to_string(), &mut main_data);
+    compile_and_run_i32(testcode.to_string(), &mut main_data);
     assert_eq!(11, main_data.my_s.mys1.field1);
     assert_eq!(12, main_data.my_s.mys1.field2);
     assert_eq!(13, main_data.my_s.mys1.field3);
@@ -174,7 +174,7 @@ fn using_enums() {
     END_PROGRAM
     "#;
 
-    compile_and_run(testcode.to_string(), &mut d);
+    compile_and_run_i32(testcode.to_string(), &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -211,7 +211,7 @@ fn using_inline_enums() {
     END_PROGRAM
     "#;
 
-    compile_and_run(testcode.to_string(), &mut d);
+    compile_and_run_i32(testcode.to_string(), &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -253,7 +253,7 @@ fn using_inline_enums_in_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run(testcode.to_string(), &mut data);
+    compile_and_run_i32(testcode.to_string(), &mut data);
     assert_eq!(2, data.tf1); //yellow
     assert_eq!(3, data.tf2); //green
     assert_eq!(2, data.tf3); //yellow
@@ -301,7 +301,7 @@ fn using_inline_arrays_in_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run(testcode.to_string(), &mut data);
+    compile_and_run_i32(testcode.to_string(), &mut data);
     assert_eq!([0, 1, 2, 3], data.arr1);
     assert_eq!([0, 10, 20, 30, 0, 0, 0, 77], data.arr2);
     assert_eq!([77, 0, -1], data.arr3);
@@ -329,7 +329,7 @@ fn using_arrays() {
     END_PROGRAM
     "#;
 
-    compile_and_run(testcode.to_string(), &mut main);
+    compile_and_run_i32(testcode.to_string(), &mut main);
     for (i, j) in main.arr.iter_mut().enumerate() {
         assert_eq!(i as i32, *j);
     }

--- a/tests/correctness/custom_datatypes.rs
+++ b/tests/correctness/custom_datatypes.rs
@@ -43,7 +43,7 @@ fn using_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_,i32>(testcode.to_string(), &mut main_data);
+    compile_and_run::<_, i32>(testcode.to_string(), &mut main_data);
     assert_eq!(3, main_data.my_s.field1);
     assert_eq!(7, main_data.my_s.field2);
     assert_eq!(10, main_data.my_s.field3);
@@ -129,7 +129,7 @@ fn using_nested_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_,i32>(testcode.to_string(), &mut main_data);
+    compile_and_run::<_, i32>(testcode.to_string(), &mut main_data);
     assert_eq!(11, main_data.my_s.mys1.field1);
     assert_eq!(12, main_data.my_s.mys1.field2);
     assert_eq!(13, main_data.my_s.mys1.field3);
@@ -174,7 +174,7 @@ fn using_enums() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_,i32>(testcode.to_string(), &mut d);
+    compile_and_run::<_, i32>(testcode.to_string(), &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -211,7 +211,7 @@ fn using_inline_enums() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_,i32>(testcode.to_string(), &mut d);
+    compile_and_run::<_, i32>(testcode.to_string(), &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -253,7 +253,7 @@ fn using_inline_enums_in_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_,i32>(testcode.to_string(), &mut data);
+    compile_and_run::<_, i32>(testcode.to_string(), &mut data);
     assert_eq!(2, data.tf1); //yellow
     assert_eq!(3, data.tf2); //green
     assert_eq!(2, data.tf3); //yellow
@@ -301,7 +301,7 @@ fn using_inline_arrays_in_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_,i32>(testcode.to_string(), &mut data);
+    compile_and_run::<_, i32>(testcode.to_string(), &mut data);
     assert_eq!([0, 1, 2, 3], data.arr1);
     assert_eq!([0, 10, 20, 30, 0, 0, 0, 77], data.arr2);
     assert_eq!([77, 0, -1], data.arr3);
@@ -329,7 +329,7 @@ fn using_arrays() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_,i32>(testcode.to_string(), &mut main);
+    compile_and_run::<_, i32>(testcode.to_string(), &mut main);
     for (i, j) in main.arr.iter_mut().enumerate() {
         assert_eq!(i as i32, *j);
     }

--- a/tests/correctness/custom_datatypes.rs
+++ b/tests/correctness/custom_datatypes.rs
@@ -43,7 +43,7 @@ fn using_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run_i32(testcode.to_string(), &mut main_data);
+    compile_and_run::<_,i32>(testcode.to_string(), &mut main_data);
     assert_eq!(3, main_data.my_s.field1);
     assert_eq!(7, main_data.my_s.field2);
     assert_eq!(10, main_data.my_s.field3);
@@ -129,7 +129,7 @@ fn using_nested_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run_i32(testcode.to_string(), &mut main_data);
+    compile_and_run::<_,i32>(testcode.to_string(), &mut main_data);
     assert_eq!(11, main_data.my_s.mys1.field1);
     assert_eq!(12, main_data.my_s.mys1.field2);
     assert_eq!(13, main_data.my_s.mys1.field3);
@@ -174,7 +174,7 @@ fn using_enums() {
     END_PROGRAM
     "#;
 
-    compile_and_run_i32(testcode.to_string(), &mut d);
+    compile_and_run::<_,i32>(testcode.to_string(), &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -211,7 +211,7 @@ fn using_inline_enums() {
     END_PROGRAM
     "#;
 
-    compile_and_run_i32(testcode.to_string(), &mut d);
+    compile_and_run::<_,i32>(testcode.to_string(), &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -253,7 +253,7 @@ fn using_inline_enums_in_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run_i32(testcode.to_string(), &mut data);
+    compile_and_run::<_,i32>(testcode.to_string(), &mut data);
     assert_eq!(2, data.tf1); //yellow
     assert_eq!(3, data.tf2); //green
     assert_eq!(2, data.tf3); //yellow
@@ -301,7 +301,7 @@ fn using_inline_arrays_in_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run_i32(testcode.to_string(), &mut data);
+    compile_and_run::<_,i32>(testcode.to_string(), &mut data);
     assert_eq!([0, 1, 2, 3], data.arr1);
     assert_eq!([0, 10, 20, 30, 0, 0, 0, 77], data.arr2);
     assert_eq!([77, 0, -1], data.arr3);
@@ -329,7 +329,7 @@ fn using_arrays() {
     END_PROGRAM
     "#;
 
-    compile_and_run_i32(testcode.to_string(), &mut main);
+    compile_and_run::<_,i32>(testcode.to_string(), &mut main);
     for (i, j) in main.arr.iter_mut().enumerate() {
         assert_eq!(i as i32, *j);
     }

--- a/tests/correctness/datatypes.rs
+++ b/tests/correctness/datatypes.rs
@@ -47,7 +47,7 @@ fn same_type_addition() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     assert_eq!(false, maintype.bool_1);
     assert_eq!(true, maintype.bool_2);
     assert_eq!(false, maintype.bool_3); //Overflow
@@ -85,7 +85,7 @@ fn byte_addition() {
         byte_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.byte_1);
     assert_eq!(0, maintype.byte_2);
     assert_eq!(254, maintype.byte_3); //Overflow
@@ -117,7 +117,7 @@ fn byte_mixed_addition() {
         int_1: 275,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(9, maintype.byte_1); //Overflow
 
     let mut maintype = Type {
@@ -126,7 +126,7 @@ fn byte_mixed_addition() {
         int_1: 10,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(20, maintype.byte_1);
 }
 
@@ -158,7 +158,7 @@ fn usint_addition() {
         usint_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.usint_1);
     assert_eq!(0, maintype.usint_2);
     assert_eq!(254, maintype.usint_3); //Overflow
@@ -190,7 +190,7 @@ fn usint_mixed_addition() {
         int_1: 275,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(9, maintype.usint_1); //Overflow
 
     let mut maintype = Type {
@@ -199,7 +199,7 @@ fn usint_mixed_addition() {
         int_1: 10,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(20, maintype.usint_1);
 }
 
@@ -231,7 +231,7 @@ fn sint_additions() {
         sint_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.sint_1);
     assert_eq!(0, maintype.sint_2);
     assert_eq!(119, maintype.sint_3); //Overflow
@@ -263,7 +263,7 @@ fn sint_mixed_addition() {
         int_1: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(-6, maintype.sint_1);
 
     let mut maintype = Type {
@@ -272,7 +272,7 @@ fn sint_mixed_addition() {
         int_1: 300,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(54, maintype.sint_1);
 }
 
@@ -304,7 +304,7 @@ fn word_addition() {
         byte_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -343,7 +343,7 @@ fn word_mixed_addition() {
         dint_1: -0xFFFFFFF,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(256, maintype.word_1);
     assert_eq!(65527, maintype.word_2);
 }
@@ -377,7 +377,7 @@ fn int_addition() {
         byte_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(-32757, maintype.byte_2);
     assert_eq!(32759, maintype.byte_3); //Overflow
@@ -411,7 +411,7 @@ fn uint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -445,7 +445,7 @@ fn dword_addition() {
         byte_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967286, maintype.byte_2);
     assert_eq!(10, maintype.byte_3); //Overflow
@@ -479,7 +479,7 @@ fn dint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(2147483638, maintype.byte_2);
     assert_eq!(-2147483639, maintype.byte_3); //overflow
@@ -513,7 +513,7 @@ fn udint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967285, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -543,7 +543,7 @@ fn unsinged_byte_expansion() {
         int_1: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(265, maintype.int_1);
 }
 
@@ -583,7 +583,7 @@ fn unsinged_byte_expansion2() {
         int_2: 0,
     };
 
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     assert_eq!(245, maintype.int_1);
     assert_eq!(65780, maintype.int_2);
 }
@@ -624,7 +624,7 @@ fn unsinged_byte_expansion3() {
         arg3: 10,
         result: 0,
     };
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     let arg1: u64 = maintype.arg1.into();
     let arg2: u64 = maintype.arg2.into();
     let arg3: u64 = maintype.arg3;
@@ -659,7 +659,7 @@ fn assign_short_string_to_long_string_variable() {
         text: [0; 81],
         text2: [0; 81],
     };
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     assert_eq!(t[0] as u8, b'a');
@@ -709,7 +709,7 @@ fn assign_string_to_string() {
         text: [0; 81],
         text2: [0; 81],
     };
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text2;
     assert_eq!(t[0] as u8, b'a');
@@ -753,7 +753,7 @@ fn assign_long_string_to_short_string_variable() {
     for (i, b) in "hello".bytes().enumerate() {
         maintype.text2[i] = b;
     }
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
@@ -801,7 +801,7 @@ fn function_parameters_string() {
         text2: [0; 81],
         text3: [0; 81],
     };
-    compile_and_run_i32(program.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
         assert_eq!(t[i], b'a');
@@ -853,7 +853,7 @@ fn real_to_int_assignment() {
         int_val2: 0,
     };
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_eq!(2, maintype.int_val);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);
@@ -892,7 +892,7 @@ fn real_float_assingment() {
         lreal_target: 0.0,
     };
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_almost_eq!(2.0, maintype.lreal_target, f64::EPSILON);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);
@@ -912,7 +912,7 @@ fn real_to_int_assignment2() {
                 main := LOG();
         END_FUNCTION
     "#;
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut Type {});
+    let res : i32 = compile_and_run(function.to_string(), &mut Type{});
     assert_eq!(1, res);
 }
 
@@ -929,6 +929,6 @@ fn lreal_to_int_assignment() {
             main := LOG();
         END_FUNCTION
     "#;
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut Type {});
+    let res : i32 = compile_and_run(function.to_string(), &mut Type{});
     assert_eq!(1, res);
 }

--- a/tests/correctness/datatypes.rs
+++ b/tests/correctness/datatypes.rs
@@ -47,7 +47,7 @@ fn same_type_addition() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     assert_eq!(false, maintype.bool_1);
     assert_eq!(true, maintype.bool_2);
     assert_eq!(false, maintype.bool_3); //Overflow
@@ -85,7 +85,7 @@ fn byte_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.byte_1);
     assert_eq!(0, maintype.byte_2);
     assert_eq!(254, maintype.byte_3); //Overflow
@@ -117,7 +117,7 @@ fn byte_mixed_addition() {
         int_1: 275,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(9, maintype.byte_1); //Overflow
 
     let mut maintype = Type {
@@ -126,7 +126,7 @@ fn byte_mixed_addition() {
         int_1: 10,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(20, maintype.byte_1);
 }
 
@@ -158,7 +158,7 @@ fn usint_addition() {
         usint_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.usint_1);
     assert_eq!(0, maintype.usint_2);
     assert_eq!(254, maintype.usint_3); //Overflow
@@ -190,7 +190,7 @@ fn usint_mixed_addition() {
         int_1: 275,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(9, maintype.usint_1); //Overflow
 
     let mut maintype = Type {
@@ -199,7 +199,7 @@ fn usint_mixed_addition() {
         int_1: 10,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(20, maintype.usint_1);
 }
 
@@ -231,7 +231,7 @@ fn sint_additions() {
         sint_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.sint_1);
     assert_eq!(0, maintype.sint_2);
     assert_eq!(119, maintype.sint_3); //Overflow
@@ -263,7 +263,7 @@ fn sint_mixed_addition() {
         int_1: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(-6, maintype.sint_1);
 
     let mut maintype = Type {
@@ -272,7 +272,7 @@ fn sint_mixed_addition() {
         int_1: 300,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(54, maintype.sint_1);
 }
 
@@ -304,7 +304,7 @@ fn word_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -343,7 +343,7 @@ fn word_mixed_addition() {
         dint_1: -0xFFFFFFF,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(256, maintype.word_1);
     assert_eq!(65527, maintype.word_2);
 }
@@ -377,7 +377,7 @@ fn int_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(-32757, maintype.byte_2);
     assert_eq!(32759, maintype.byte_3); //Overflow
@@ -411,7 +411,7 @@ fn uint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -445,7 +445,7 @@ fn dword_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967286, maintype.byte_2);
     assert_eq!(10, maintype.byte_3); //Overflow
@@ -479,7 +479,7 @@ fn dint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(2147483638, maintype.byte_2);
     assert_eq!(-2147483639, maintype.byte_3); //overflow
@@ -513,7 +513,7 @@ fn udint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967285, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -543,7 +543,7 @@ fn unsinged_byte_expansion() {
         int_1: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(265, maintype.int_1);
 }
 
@@ -583,7 +583,7 @@ fn unsinged_byte_expansion2() {
         int_2: 0,
     };
 
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     assert_eq!(245, maintype.int_1);
     assert_eq!(65780, maintype.int_2);
 }
@@ -624,7 +624,7 @@ fn unsinged_byte_expansion3() {
         arg3: 10,
         result: 0,
     };
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     let arg1: u64 = maintype.arg1.into();
     let arg2: u64 = maintype.arg2.into();
     let arg3: u64 = maintype.arg3;
@@ -659,7 +659,7 @@ fn assign_short_string_to_long_string_variable() {
         text: [0; 81],
         text2: [0; 81],
     };
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     assert_eq!(t[0] as u8, b'a');
@@ -709,7 +709,7 @@ fn assign_string_to_string() {
         text: [0; 81],
         text2: [0; 81],
     };
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text2;
     assert_eq!(t[0] as u8, b'a');
@@ -753,7 +753,7 @@ fn assign_long_string_to_short_string_variable() {
     for (i, b) in "hello".bytes().enumerate() {
         maintype.text2[i] = b;
     }
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
@@ -801,7 +801,7 @@ fn function_parameters_string() {
         text2: [0; 81],
         text3: [0; 81],
     };
-    compile_and_run::<_,i32>(program.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
         assert_eq!(t[i], b'a');
@@ -853,7 +853,7 @@ fn real_to_int_assignment() {
         int_val2: 0,
     };
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_eq!(2, maintype.int_val);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);
@@ -892,7 +892,7 @@ fn real_float_assingment() {
         lreal_target: 0.0,
     };
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_almost_eq!(2.0, maintype.lreal_target, f64::EPSILON);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);
@@ -912,7 +912,7 @@ fn real_to_int_assignment2() {
                 main := LOG();
         END_FUNCTION
     "#;
-    let res : i32 = compile_and_run(function.to_string(), &mut Type{});
+    let res: i32 = compile_and_run(function.to_string(), &mut Type {});
     assert_eq!(1, res);
 }
 
@@ -929,6 +929,6 @@ fn lreal_to_int_assignment() {
             main := LOG();
         END_FUNCTION
     "#;
-    let res : i32 = compile_and_run(function.to_string(), &mut Type{});
+    let res: i32 = compile_and_run(function.to_string(), &mut Type {});
     assert_eq!(1, res);
 }

--- a/tests/correctness/datatypes.rs
+++ b/tests/correctness/datatypes.rs
@@ -47,7 +47,7 @@ fn same_type_addition() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     assert_eq!(false, maintype.bool_1);
     assert_eq!(true, maintype.bool_2);
     assert_eq!(false, maintype.bool_3); //Overflow
@@ -85,7 +85,7 @@ fn byte_addition() {
         byte_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.byte_1);
     assert_eq!(0, maintype.byte_2);
     assert_eq!(254, maintype.byte_3); //Overflow
@@ -117,7 +117,7 @@ fn byte_mixed_addition() {
         int_1: 275,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(9, maintype.byte_1); //Overflow
 
     let mut maintype = Type {
@@ -126,7 +126,7 @@ fn byte_mixed_addition() {
         int_1: 10,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(20, maintype.byte_1);
 }
 
@@ -158,7 +158,7 @@ fn usint_addition() {
         usint_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.usint_1);
     assert_eq!(0, maintype.usint_2);
     assert_eq!(254, maintype.usint_3); //Overflow
@@ -190,7 +190,7 @@ fn usint_mixed_addition() {
         int_1: 275,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(9, maintype.usint_1); //Overflow
 
     let mut maintype = Type {
@@ -199,7 +199,7 @@ fn usint_mixed_addition() {
         int_1: 10,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(20, maintype.usint_1);
 }
 
@@ -231,7 +231,7 @@ fn sint_additions() {
         sint_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(2, maintype.sint_1);
     assert_eq!(0, maintype.sint_2);
     assert_eq!(119, maintype.sint_3); //Overflow
@@ -263,7 +263,7 @@ fn sint_mixed_addition() {
         int_1: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(-6, maintype.sint_1);
 
     let mut maintype = Type {
@@ -272,7 +272,7 @@ fn sint_mixed_addition() {
         int_1: 300,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(54, maintype.sint_1);
 }
 
@@ -304,7 +304,7 @@ fn word_addition() {
         byte_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -343,7 +343,7 @@ fn word_mixed_addition() {
         dint_1: -0xFFFFFFF,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(256, maintype.word_1);
     assert_eq!(65527, maintype.word_2);
 }
@@ -377,7 +377,7 @@ fn int_addition() {
         byte_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(-32757, maintype.byte_2);
     assert_eq!(32759, maintype.byte_3); //Overflow
@@ -411,7 +411,7 @@ fn uint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -445,7 +445,7 @@ fn dword_addition() {
         byte_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967286, maintype.byte_2);
     assert_eq!(10, maintype.byte_3); //Overflow
@@ -479,7 +479,7 @@ fn dint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(2147483638, maintype.byte_2);
     assert_eq!(-2147483639, maintype.byte_3); //overflow
@@ -513,7 +513,7 @@ fn udint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967285, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -543,7 +543,7 @@ fn unsinged_byte_expansion() {
         int_1: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(265, maintype.int_1);
 }
 
@@ -583,7 +583,7 @@ fn unsinged_byte_expansion2() {
         int_2: 0,
     };
 
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     assert_eq!(245, maintype.int_1);
     assert_eq!(65780, maintype.int_2);
 }
@@ -624,7 +624,7 @@ fn unsinged_byte_expansion3() {
         arg3: 10,
         result: 0,
     };
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     let arg1: u64 = maintype.arg1.into();
     let arg2: u64 = maintype.arg2.into();
     let arg3: u64 = maintype.arg3;
@@ -659,7 +659,7 @@ fn assign_short_string_to_long_string_variable() {
         text: [0; 81],
         text2: [0; 81],
     };
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     assert_eq!(t[0] as u8, b'a');
@@ -709,7 +709,7 @@ fn assign_string_to_string() {
         text: [0; 81],
         text2: [0; 81],
     };
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text2;
     assert_eq!(t[0] as u8, b'a');
@@ -753,7 +753,7 @@ fn assign_long_string_to_short_string_variable() {
     for (i, b) in "hello".bytes().enumerate() {
         maintype.text2[i] = b;
     }
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
@@ -801,7 +801,7 @@ fn function_parameters_string() {
         text2: [0; 81],
         text3: [0; 81],
     };
-    compile_and_run(program.to_string(), &mut maintype);
+    compile_and_run_i32(program.to_string(), &mut maintype);
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
         assert_eq!(t[i], b'a');
@@ -853,7 +853,7 @@ fn real_to_int_assignment() {
         int_val2: 0,
     };
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_eq!(2, maintype.int_val);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);
@@ -892,7 +892,7 @@ fn real_float_assingment() {
         lreal_target: 0.0,
     };
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_almost_eq!(2.0, maintype.lreal_target, f64::EPSILON);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);
@@ -912,7 +912,7 @@ fn real_to_int_assignment2() {
                 main := LOG();
         END_FUNCTION
     "#;
-    let (res, _) = compile_and_run(function.to_string(), &mut Type {});
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut Type {});
     assert_eq!(1, res);
 }
 
@@ -929,6 +929,6 @@ fn lreal_to_int_assignment() {
             main := LOG();
         END_FUNCTION
     "#;
-    let (res, _) = compile_and_run(function.to_string(), &mut Type {});
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut Type {});
     assert_eq!(1, res);
 }

--- a/tests/correctness/external_functions.rs
+++ b/tests/correctness/external_functions.rs
@@ -43,7 +43,7 @@ fn test_external_function_called() {
     let fn_value = code_gen.module.get_function("times_two").unwrap();
 
     exec_engine.add_global_mapping(&fn_value, times_two as usize);
-    let (res, _) = run_i32(&exec_engine, "main", &mut MainType { ret: 0 });
+    let res : i32 = run(&exec_engine, "main", &mut MainType { ret: 0 });
     assert_eq!(res, 200)
 
     //Call that function

--- a/tests/correctness/external_functions.rs
+++ b/tests/correctness/external_functions.rs
@@ -43,7 +43,7 @@ fn test_external_function_called() {
     let fn_value = code_gen.module.get_function("times_two").unwrap();
 
     exec_engine.add_global_mapping(&fn_value, times_two as usize);
-    let (res, _) = run(&exec_engine, "main", &mut MainType { ret: 0 });
+    let (res, _) = run_i32(&exec_engine, "main", &mut MainType { ret: 0 });
     assert_eq!(res, 200)
 
     //Call that function

--- a/tests/correctness/external_functions.rs
+++ b/tests/correctness/external_functions.rs
@@ -43,7 +43,7 @@ fn test_external_function_called() {
     let fn_value = code_gen.module.get_function("times_two").unwrap();
 
     exec_engine.add_global_mapping(&fn_value, times_two as usize);
-    let res : i32 = run(&exec_engine, "main", &mut MainType { ret: 0 });
+    let res: i32 = run(&exec_engine, "main", &mut MainType { ret: 0 });
     assert_eq!(res, 200)
 
     //Call that function

--- a/tests/correctness/functions.rs
+++ b/tests/correctness/functions.rs
@@ -46,9 +46,9 @@ fn max_function() {
         the_b: -2,
     };
 
-    let (res, _) = run_i32(&engine, "main", &mut case1);
+    let res : i32 = run(&engine, "main", &mut case1);
     assert_eq!(res, 7);
-    let (res, _) = run_i32(&engine, "main", &mut case2);
+    let res : i32 = run(&engine, "main", &mut case2);
     assert_eq!(res, 9);
 }
 
@@ -81,7 +81,7 @@ fn nested_function_call() {
             END_FUNCTION
         "#;
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut main_data);
+    let res : i32 = compile_and_run(function.to_string(), &mut main_data);
     assert_eq!(1000, res);
 }
 
@@ -126,7 +126,7 @@ fn test_or_sideeffects() {
     let context: Context = Context::create();
     let engine = compile(&context, function);
     let mut case1 = MainType { x: false };
-    let (res, _) = run_i32(&engine, "main", &mut case1);
+    let res : i32 = run(&engine, "main", &mut case1);
     assert_eq!(res, 31);
 }
 
@@ -171,7 +171,7 @@ fn test_and_sideeffects() {
     let context: Context = Context::create();
     let engine = compile(&context, function);
     let mut case1 = MainType { x: false };
-    let (res, _) = run_i32(&engine, "main", &mut case1);
+    let res : i32 = run(&engine, "main", &mut case1);
     assert_eq!(res, 31);
 }
 
@@ -212,7 +212,7 @@ fn function_block_instances_save_state_per_instance() {
         f: FooType { i: 0 },
         j: FooType { i: 0 },
     };
-    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
+    compile_and_run::<_,i32>(function.to_string(), &mut interface);
     assert_eq!(interface.f.i, 2);
     assert_eq!(interface.j.i, 7);
 }
@@ -241,8 +241,8 @@ fn program_instances_save_state_per() {
     };
     let context = inkwell::context::Context::create();
     let exec_engine = compile(&context, function.to_string());
-    run_i32(&exec_engine, "main", &mut interface);
-    run_i32(&exec_engine, "main", &mut interface);
+    run::<_,i32>(&exec_engine, "main", &mut interface);
+    run::<_,i32>(&exec_engine, "main", &mut interface);
     assert_eq!(interface.f.i, 6);
 }
 
@@ -270,7 +270,7 @@ fn functions_can_be_called_out_of_order() {
     "#;
 
     let mut interface = MainType { f: 0 };
-    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
+    compile_and_run::<_,i32>(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.f);
 }
@@ -336,7 +336,7 @@ fn function_block_instances_save_state_per_instance_2() {
             baz: BazType { i: 0 },
         },
     };
-    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
+    compile_and_run::<_,i32>(function.to_string(), &mut interface);
 
     assert_eq!(2, interface.f.baz.i);
     assert_eq!(4, interface.j.baz.i);
@@ -378,7 +378,7 @@ fn function_call_inout_variable() {
     "#;
 
     let mut interface = MainType { baz: 7 };
-    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
+    compile_and_run::<_,i32>(function.to_string(), &mut interface);
 
     assert_eq!(64, interface.baz);
 }
@@ -429,7 +429,7 @@ fn inouts_behave_like_pointers() {
         p2: 0,
         p3: 0,
     };
-    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
+    compile_and_run::<_,i32>(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.p1);
     assert_eq!(8, interface.p2);

--- a/tests/correctness/functions.rs
+++ b/tests/correctness/functions.rs
@@ -46,9 +46,9 @@ fn max_function() {
         the_b: -2,
     };
 
-    let (res, _) = run(&engine, "main", &mut case1);
+    let (res, _) = run_i32(&engine, "main", &mut case1);
     assert_eq!(res, 7);
-    let (res, _) = run(&engine, "main", &mut case2);
+    let (res, _) = run_i32(&engine, "main", &mut case2);
     assert_eq!(res, 9);
 }
 
@@ -81,7 +81,7 @@ fn nested_function_call() {
             END_FUNCTION
         "#;
 
-    let (res, _) = compile_and_run(function.to_string(), &mut main_data);
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut main_data);
     assert_eq!(1000, res);
 }
 
@@ -126,7 +126,7 @@ fn test_or_sideeffects() {
     let context: Context = Context::create();
     let engine = compile(&context, function);
     let mut case1 = MainType { x: false };
-    let (res, _) = run(&engine, "main", &mut case1);
+    let (res, _) = run_i32(&engine, "main", &mut case1);
     assert_eq!(res, 31);
 }
 
@@ -171,7 +171,7 @@ fn test_and_sideeffects() {
     let context: Context = Context::create();
     let engine = compile(&context, function);
     let mut case1 = MainType { x: false };
-    let (res, _) = run(&engine, "main", &mut case1);
+    let (res, _) = run_i32(&engine, "main", &mut case1);
     assert_eq!(res, 31);
 }
 
@@ -212,7 +212,7 @@ fn function_block_instances_save_state_per_instance() {
         f: FooType { i: 0 },
         j: FooType { i: 0 },
     };
-    let (_, _) = compile_and_run(function.to_string(), &mut interface);
+    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
     assert_eq!(interface.f.i, 2);
     assert_eq!(interface.j.i, 7);
 }
@@ -241,8 +241,8 @@ fn program_instances_save_state_per() {
     };
     let context = inkwell::context::Context::create();
     let exec_engine = compile(&context, function.to_string());
-    run(&exec_engine, "main", &mut interface);
-    run(&exec_engine, "main", &mut interface);
+    run_i32(&exec_engine, "main", &mut interface);
+    run_i32(&exec_engine, "main", &mut interface);
     assert_eq!(interface.f.i, 6);
 }
 
@@ -270,7 +270,7 @@ fn functions_can_be_called_out_of_order() {
     "#;
 
     let mut interface = MainType { f: 0 };
-    let (_, _) = compile_and_run(function.to_string(), &mut interface);
+    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.f);
 }
@@ -336,7 +336,7 @@ fn function_block_instances_save_state_per_instance_2() {
             baz: BazType { i: 0 },
         },
     };
-    let (_, _) = compile_and_run(function.to_string(), &mut interface);
+    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
 
     assert_eq!(2, interface.f.baz.i);
     assert_eq!(4, interface.j.baz.i);
@@ -378,7 +378,7 @@ fn function_call_inout_variable() {
     "#;
 
     let mut interface = MainType { baz: 7 };
-    let (_, _) = compile_and_run(function.to_string(), &mut interface);
+    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
 
     assert_eq!(64, interface.baz);
 }
@@ -429,7 +429,7 @@ fn inouts_behave_like_pointers() {
         p2: 0,
         p3: 0,
     };
-    let (_, _) = compile_and_run(function.to_string(), &mut interface);
+    let (_, _) = compile_and_run_i32(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.p1);
     assert_eq!(8, interface.p2);

--- a/tests/correctness/functions.rs
+++ b/tests/correctness/functions.rs
@@ -46,9 +46,9 @@ fn max_function() {
         the_b: -2,
     };
 
-    let res : i32 = run(&engine, "main", &mut case1);
+    let res: i32 = run(&engine, "main", &mut case1);
     assert_eq!(res, 7);
-    let res : i32 = run(&engine, "main", &mut case2);
+    let res: i32 = run(&engine, "main", &mut case2);
     assert_eq!(res, 9);
 }
 
@@ -81,7 +81,7 @@ fn nested_function_call() {
             END_FUNCTION
         "#;
 
-    let res : i32 = compile_and_run(function.to_string(), &mut main_data);
+    let res: i32 = compile_and_run(function.to_string(), &mut main_data);
     assert_eq!(1000, res);
 }
 
@@ -126,7 +126,7 @@ fn test_or_sideeffects() {
     let context: Context = Context::create();
     let engine = compile(&context, function);
     let mut case1 = MainType { x: false };
-    let res : i32 = run(&engine, "main", &mut case1);
+    let res: i32 = run(&engine, "main", &mut case1);
     assert_eq!(res, 31);
 }
 
@@ -171,7 +171,7 @@ fn test_and_sideeffects() {
     let context: Context = Context::create();
     let engine = compile(&context, function);
     let mut case1 = MainType { x: false };
-    let res : i32 = run(&engine, "main", &mut case1);
+    let res: i32 = run(&engine, "main", &mut case1);
     assert_eq!(res, 31);
 }
 
@@ -212,7 +212,7 @@ fn function_block_instances_save_state_per_instance() {
         f: FooType { i: 0 },
         j: FooType { i: 0 },
     };
-    compile_and_run::<_,i32>(function.to_string(), &mut interface);
+    compile_and_run::<_, i32>(function.to_string(), &mut interface);
     assert_eq!(interface.f.i, 2);
     assert_eq!(interface.j.i, 7);
 }
@@ -241,8 +241,8 @@ fn program_instances_save_state_per() {
     };
     let context = inkwell::context::Context::create();
     let exec_engine = compile(&context, function.to_string());
-    run::<_,i32>(&exec_engine, "main", &mut interface);
-    run::<_,i32>(&exec_engine, "main", &mut interface);
+    run::<_, i32>(&exec_engine, "main", &mut interface);
+    run::<_, i32>(&exec_engine, "main", &mut interface);
     assert_eq!(interface.f.i, 6);
 }
 
@@ -270,7 +270,7 @@ fn functions_can_be_called_out_of_order() {
     "#;
 
     let mut interface = MainType { f: 0 };
-    compile_and_run::<_,i32>(function.to_string(), &mut interface);
+    compile_and_run::<_, i32>(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.f);
 }
@@ -336,7 +336,7 @@ fn function_block_instances_save_state_per_instance_2() {
             baz: BazType { i: 0 },
         },
     };
-    compile_and_run::<_,i32>(function.to_string(), &mut interface);
+    compile_and_run::<_, i32>(function.to_string(), &mut interface);
 
     assert_eq!(2, interface.f.baz.i);
     assert_eq!(4, interface.j.baz.i);
@@ -378,7 +378,7 @@ fn function_call_inout_variable() {
     "#;
 
     let mut interface = MainType { baz: 7 };
-    compile_and_run::<_,i32>(function.to_string(), &mut interface);
+    compile_and_run::<_, i32>(function.to_string(), &mut interface);
 
     assert_eq!(64, interface.baz);
 }
@@ -429,7 +429,7 @@ fn inouts_behave_like_pointers() {
         p2: 0,
         p3: 0,
     };
-    compile_and_run::<_,i32>(function.to_string(), &mut interface);
+    compile_and_run::<_, i32>(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.p1);
     assert_eq!(8, interface.p2);

--- a/tests/correctness/global_variables.rs
+++ b/tests/correctness/global_variables.rs
@@ -35,7 +35,7 @@ fn global_variable_can_be_referenced_in_fn() {
     main := gX;
     END_FUNCTION
     ";
-    let res : i32 = compile_and_run(function.to_string(), &mut MainType { x: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { x: 0, ret: 0 });
     assert_eq!(res, 30);
 }
 
@@ -65,9 +65,9 @@ fn global_variable_can_be_referenced_in_two_functions() {
     let context = inkwell::context::Context::create();
     let exec_engine = compile(&context, function.to_string());
 
-    let res : i32 = run(&exec_engine, "main", &mut MainType { x: 0, ret: 0 });
+    let res: i32 = run(&exec_engine, "main", &mut MainType { x: 0, ret: 0 });
     assert_eq!(res, 30);
-    let res2 : i32 = run(&exec_engine, "two", &mut MainType { x: 0, ret: 0 });
+    let res2: i32 = run(&exec_engine, "two", &mut MainType { x: 0, ret: 0 });
     assert_eq!(res2, 30)
 }
 
@@ -98,7 +98,7 @@ fn global_variables_with_initialization() {
         y: false,
         z: 0.0,
     };
-    run::<_,i32>(&exec_engine, "main", &mut params);
+    run::<_, i32>(&exec_engine, "main", &mut params);
     assert_eq!(
         params,
         MainGlobalsType {

--- a/tests/correctness/global_variables.rs
+++ b/tests/correctness/global_variables.rs
@@ -35,7 +35,7 @@ fn global_variable_can_be_referenced_in_fn() {
     main := gX;
     END_FUNCTION
     ";
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { x: 0, ret: 0 });
+    let res : i32 = compile_and_run(function.to_string(), &mut MainType { x: 0, ret: 0 });
     assert_eq!(res, 30);
 }
 
@@ -65,9 +65,9 @@ fn global_variable_can_be_referenced_in_two_functions() {
     let context = inkwell::context::Context::create();
     let exec_engine = compile(&context, function.to_string());
 
-    let (res, _) = run_i32(&exec_engine, "main", &mut MainType { x: 0, ret: 0 });
+    let res : i32 = run(&exec_engine, "main", &mut MainType { x: 0, ret: 0 });
     assert_eq!(res, 30);
-    let (res2, _) = run_i32(&exec_engine, "two", &mut MainType { x: 0, ret: 0 });
+    let res2 : i32 = run(&exec_engine, "two", &mut MainType { x: 0, ret: 0 });
     assert_eq!(res2, 30)
 }
 
@@ -98,7 +98,7 @@ fn global_variables_with_initialization() {
         y: false,
         z: 0.0,
     };
-    run_i32(&exec_engine, "main", &mut params);
+    run::<_,i32>(&exec_engine, "main", &mut params);
     assert_eq!(
         params,
         MainGlobalsType {

--- a/tests/correctness/global_variables.rs
+++ b/tests/correctness/global_variables.rs
@@ -35,7 +35,7 @@ fn global_variable_can_be_referenced_in_fn() {
     main := gX;
     END_FUNCTION
     ";
-    let (res, _) = compile_and_run(function.to_string(), &mut MainType { x: 0, ret: 0 });
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut MainType { x: 0, ret: 0 });
     assert_eq!(res, 30);
 }
 
@@ -65,9 +65,9 @@ fn global_variable_can_be_referenced_in_two_functions() {
     let context = inkwell::context::Context::create();
     let exec_engine = compile(&context, function.to_string());
 
-    let (res, _) = run(&exec_engine, "main", &mut MainType { x: 0, ret: 0 });
+    let (res, _) = run_i32(&exec_engine, "main", &mut MainType { x: 0, ret: 0 });
     assert_eq!(res, 30);
-    let (res2, _) = run(&exec_engine, "two", &mut MainType { x: 0, ret: 0 });
+    let (res2, _) = run_i32(&exec_engine, "two", &mut MainType { x: 0, ret: 0 });
     assert_eq!(res2, 30)
 }
 
@@ -98,7 +98,7 @@ fn global_variables_with_initialization() {
         y: false,
         z: 0.0,
     };
-    run(&exec_engine, "main", &mut params);
+    run_i32(&exec_engine, "main", &mut params);
     assert_eq!(
         params,
         MainGlobalsType {

--- a/tests/correctness/initial_values.rs
+++ b/tests/correctness/initial_values.rs
@@ -61,7 +61,7 @@ fn initia_values_of_programs_members() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -109,7 +109,7 @@ fn initia_values_of_functionblock_members() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -155,7 +155,7 @@ fn initia_values_of_function_members() {
 
     let mut maintype = ThreeInts { x: 0, y: 0, z: 0 };
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(88, maintype.y);
@@ -200,7 +200,7 @@ fn initia_values_of_struct_type_members() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -246,7 +246,7 @@ fn initia_values_of_alias_type() {
 
     let mut maintype = new();
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
 
     assert_eq!(7, maintype.x);
     assert_eq!(8, maintype.x_);
@@ -339,7 +339,7 @@ fn initial_values_in_single_dimension_array_variable() {
         h2: true,
     };
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(3, maintype.a2);
     assert_eq!(4, maintype.b0);
@@ -395,7 +395,7 @@ fn initial_values_in_multi_dimension_array_variable() {
         a3: 0,
     };
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(2, maintype.a1);
     assert_eq!(3, maintype.a2);
@@ -455,7 +455,7 @@ fn initial_values_in_array_of_array_variable() {
         a8: 0,
     };
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a1);
     assert_eq!(2, maintype.a2);
     assert_eq!(3, maintype.a3);
@@ -504,7 +504,7 @@ fn real_initial_values_in_array_variable() {
         r2: 0.0,
     };
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     assert_almost_eq!(9.1415, maintype.f1, f32::EPSILON);
     assert_almost_eq!(0.001, maintype.f2, f32::EPSILON);
     assert_almost_eq!(9.141592653589, maintype.r1, f64::EPSILON);
@@ -570,7 +570,7 @@ fn initialization_of_complex_struct_instance() {
         f: 0.0,
     };
 
-    compile_and_run_i32(src.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(2, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -629,7 +629,7 @@ fn initialization_of_complex_struct_instance_using_defaults() {
         f: 0.0,
     };
 
-    compile_and_run_i32(src.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(7, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -689,7 +689,7 @@ fn initialization_of_string_variables() {
         string3: [1; 21],
     };
 
-    compile_and_run_i32(src.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(src.to_string(), &mut maintype);
     assert_eq!(
         &maintype.mystring1[0..8],
         [97, 98, 99, 100, 101, 102, 103, 0]

--- a/tests/correctness/initial_values.rs
+++ b/tests/correctness/initial_values.rs
@@ -61,7 +61,7 @@ fn initia_values_of_programs_members() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -109,7 +109,7 @@ fn initia_values_of_functionblock_members() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -155,7 +155,7 @@ fn initia_values_of_function_members() {
 
     let mut maintype = ThreeInts { x: 0, y: 0, z: 0 };
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(88, maintype.y);
@@ -200,7 +200,7 @@ fn initia_values_of_struct_type_members() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -246,7 +246,7 @@ fn initia_values_of_alias_type() {
 
     let mut maintype = new();
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
 
     assert_eq!(7, maintype.x);
     assert_eq!(8, maintype.x_);
@@ -339,7 +339,7 @@ fn initial_values_in_single_dimension_array_variable() {
         h2: true,
     };
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(3, maintype.a2);
     assert_eq!(4, maintype.b0);
@@ -395,7 +395,7 @@ fn initial_values_in_multi_dimension_array_variable() {
         a3: 0,
     };
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(2, maintype.a1);
     assert_eq!(3, maintype.a2);
@@ -455,7 +455,7 @@ fn initial_values_in_array_of_array_variable() {
         a8: 0,
     };
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a1);
     assert_eq!(2, maintype.a2);
     assert_eq!(3, maintype.a3);
@@ -504,7 +504,7 @@ fn real_initial_values_in_array_variable() {
         r2: 0.0,
     };
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     assert_almost_eq!(9.1415, maintype.f1, f32::EPSILON);
     assert_almost_eq!(0.001, maintype.f2, f32::EPSILON);
     assert_almost_eq!(9.141592653589, maintype.r1, f64::EPSILON);
@@ -570,7 +570,7 @@ fn initialization_of_complex_struct_instance() {
         f: 0.0,
     };
 
-    compile_and_run(src.to_string(), &mut maintype);
+    compile_and_run_i32(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(2, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -629,7 +629,7 @@ fn initialization_of_complex_struct_instance_using_defaults() {
         f: 0.0,
     };
 
-    compile_and_run(src.to_string(), &mut maintype);
+    compile_and_run_i32(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(7, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -689,7 +689,7 @@ fn initialization_of_string_variables() {
         string3: [1; 21],
     };
 
-    compile_and_run(src.to_string(), &mut maintype);
+    compile_and_run_i32(src.to_string(), &mut maintype);
     assert_eq!(
         &maintype.mystring1[0..8],
         [97, 98, 99, 100, 101, 102, 103, 0]

--- a/tests/correctness/initial_values.rs
+++ b/tests/correctness/initial_values.rs
@@ -61,7 +61,7 @@ fn initia_values_of_programs_members() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -109,7 +109,7 @@ fn initia_values_of_functionblock_members() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -155,7 +155,7 @@ fn initia_values_of_function_members() {
 
     let mut maintype = ThreeInts { x: 0, y: 0, z: 0 };
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(88, maintype.y);
@@ -200,7 +200,7 @@ fn initia_values_of_struct_type_members() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -246,7 +246,7 @@ fn initia_values_of_alias_type() {
 
     let mut maintype = new();
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
 
     assert_eq!(7, maintype.x);
     assert_eq!(8, maintype.x_);
@@ -339,7 +339,7 @@ fn initial_values_in_single_dimension_array_variable() {
         h2: true,
     };
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(3, maintype.a2);
     assert_eq!(4, maintype.b0);
@@ -395,7 +395,7 @@ fn initial_values_in_multi_dimension_array_variable() {
         a3: 0,
     };
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(2, maintype.a1);
     assert_eq!(3, maintype.a2);
@@ -455,7 +455,7 @@ fn initial_values_in_array_of_array_variable() {
         a8: 0,
     };
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a1);
     assert_eq!(2, maintype.a2);
     assert_eq!(3, maintype.a3);
@@ -504,7 +504,7 @@ fn real_initial_values_in_array_variable() {
         r2: 0.0,
     };
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     assert_almost_eq!(9.1415, maintype.f1, f32::EPSILON);
     assert_almost_eq!(0.001, maintype.f2, f32::EPSILON);
     assert_almost_eq!(9.141592653589, maintype.r1, f64::EPSILON);
@@ -570,7 +570,7 @@ fn initialization_of_complex_struct_instance() {
         f: 0.0,
     };
 
-    compile_and_run::<_,i32>(src.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(2, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -629,7 +629,7 @@ fn initialization_of_complex_struct_instance_using_defaults() {
         f: 0.0,
     };
 
-    compile_and_run::<_,i32>(src.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(7, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -689,7 +689,7 @@ fn initialization_of_string_variables() {
         string3: [1; 21],
     };
 
-    compile_and_run::<_,i32>(src.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(src.to_string(), &mut maintype);
     assert_eq!(
         &maintype.mystring1[0..8],
         [97, 98, 99, 100, 101, 102, 103, 0]

--- a/tests/correctness/pointers.rs
+++ b/tests/correctness/pointers.rs
@@ -35,7 +35,7 @@ END_FUNCTION
 
     let mut maintype = MainType {};
 
-    let res : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let res: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(36, res);
 }

--- a/tests/correctness/pointers.rs
+++ b/tests/correctness/pointers.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::compile_and_run;
+use crate::compile_and_run_i32;
 
 #[allow(dead_code)]
 #[repr(C)]
@@ -35,7 +35,7 @@ END_FUNCTION
 
     let mut maintype = MainType {};
 
-    let (res, _) = compile_and_run(function.to_string(), &mut maintype);
+    let (res, _) = compile_and_run_i32(function.to_string(), &mut maintype);
 
     assert_eq!(36, res);
 }

--- a/tests/correctness/pointers.rs
+++ b/tests/correctness/pointers.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::compile_and_run_i32;
+use crate::compile_and_run;
 
 #[allow(dead_code)]
 #[repr(C)]
@@ -35,7 +35,7 @@ END_FUNCTION
 
     let mut maintype = MainType {};
 
-    let (res, _) = compile_and_run_i32(function.to_string(), &mut maintype);
+    let res : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(36, res);
 }

--- a/tests/correctness/sub_range_types.rs
+++ b/tests/correctness/sub_range_types.rs
@@ -70,7 +70,7 @@ fn sub_range_chooses_right_implementation() {
         _ulint: 0,
     };
 
-    compile_and_run_i32(function.to_string(), &mut maintype);
+    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
     let expected = MainType {
         _byte: 7,
         _sint: -7,

--- a/tests/correctness/sub_range_types.rs
+++ b/tests/correctness/sub_range_types.rs
@@ -70,7 +70,7 @@ fn sub_range_chooses_right_implementation() {
         _ulint: 0,
     };
 
-    compile_and_run::<_,i32>(function.to_string(), &mut maintype);
+    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
     let expected = MainType {
         _byte: 7,
         _sint: -7,

--- a/tests/correctness/sub_range_types.rs
+++ b/tests/correctness/sub_range_types.rs
@@ -70,7 +70,7 @@ fn sub_range_chooses_right_implementation() {
         _ulint: 0,
     };
 
-    compile_and_run(function.to_string(), &mut maintype);
+    compile_and_run_i32(function.to_string(), &mut maintype);
     let expected = MainType {
         _byte: 7,
         _sint: -7,

--- a/tests/correctness/sums.rs
+++ b/tests/correctness/sums.rs
@@ -28,7 +28,7 @@ fn int_division_in_result() {
     END_FUNCTION
     ";
 
-    let (res, _) = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let (res, _) = compile_and_run::<_,i32>(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 300)
 }
 
@@ -41,6 +41,6 @@ fn real_division_in_result() {
     END_FUNCTION
     ";
 
-    let (res, _) = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let (res, _) = compile_and_run::<_,i32>(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 333)
 }

--- a/tests/correctness/sums.rs
+++ b/tests/correctness/sums.rs
@@ -15,7 +15,7 @@ fn adds_in_result() {
     END_FUNCTION
     ";
 
-    let (res, _) = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 60)
 }
 
@@ -28,7 +28,7 @@ fn int_division_in_result() {
     END_FUNCTION
     ";
 
-    let (res, _) = compile_and_run::<_,i32>(prog.to_string(), &mut MainType { ret: 0 });
+    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 300)
 }
 
@@ -41,7 +41,7 @@ fn real_division_in_result() {
     END_FUNCTION
     ";
 
-    let (res, _) = compile_and_run::<_,i32>(prog.to_string(), &mut MainType { ret: 0 });
+    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 333)
 }
 
@@ -52,7 +52,7 @@ fn order_of_operations_sum() {
     main := (6 * 100) + (600 / 6) - 500 + (200 / 20) - 210;
     END_FUNCTION
     ";
-    let (res, _) = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 0)
 }
 
@@ -63,6 +63,6 @@ fn order_of_operations_mul() {
     main := 10 * 10 / 5 / 2;
     END_FUNCTION
     ";
-    let (res, _) = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 10)
 }

--- a/tests/correctness/sums.rs
+++ b/tests/correctness/sums.rs
@@ -15,7 +15,7 @@ fn adds_in_result() {
     END_FUNCTION
     ";
 
-    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 60)
 }
 
@@ -28,7 +28,7 @@ fn int_division_in_result() {
     END_FUNCTION
     ";
 
-    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 300)
 }
 
@@ -41,7 +41,7 @@ fn real_division_in_result() {
     END_FUNCTION
     ";
 
-    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 333)
 }
 
@@ -52,7 +52,7 @@ fn order_of_operations_sum() {
     main := (6 * 100) + (600 / 6) - 500 + (200 / 20) - 210;
     END_FUNCTION
     ";
-    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 0)
 }
 
@@ -63,6 +63,6 @@ fn order_of_operations_mul() {
     main := 10 * 10 / 5 / 2;
     END_FUNCTION
     ";
-    let res : i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
+    let res: i32 = compile_and_run(prog.to_string(), &mut MainType { ret: 0 });
     assert_eq!(res, 10)
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -63,26 +63,17 @@ pub fn compile(context: &Context, source: String) -> ExecutionEngine {
         .unwrap()
 }
 
-pub fn compile_and_run_i32<T>(source: String, params: &mut T) -> (i32, &'static str) {
-    compile_and_run::<_,i32>(source, params)
-}
-
-pub fn compile_and_run<T,U>(source: String, params: &mut T) -> (U, &'static str) {
+pub fn compile_and_run<T,U>(source: String, params: &mut T) -> U {
     let context: Context = Context::create();
     let exec_engine = compile(&context, source);
     run::<T,U>(&exec_engine, "main", params)
 }
 
-pub fn run_i32<T>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> (i32, &'static str) {
-    run::<_,i32>(exec_engine, name, params)
-}
-
-
-pub fn run<T,U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> (U, &'static str) {
+pub fn run<T,U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {
     unsafe {
         let main: JitFunction<MainFunction<T,U>> = exec_engine.get_function(name).unwrap();
         let main_t_ptr = &mut *params as *mut _;
         let int_res = main.call(main_t_ptr);
-        (int_res, "")
+        int_res
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,7 +3,7 @@ use inkwell::context::Context;
 use inkwell::execution_engine::{ExecutionEngine, JitFunction};
 use rusty::*;
 
-type MainFunction<T,U> = unsafe extern "C" fn(*mut T) -> U;
+type MainFunction<T, U> = unsafe extern "C" fn(*mut T) -> U;
 
 mod correctness {
     mod arrays;
@@ -63,15 +63,15 @@ pub fn compile(context: &Context, source: String) -> ExecutionEngine {
         .unwrap()
 }
 
-pub fn compile_and_run<T,U>(source: String, params: &mut T) -> U {
+pub fn compile_and_run<T, U>(source: String, params: &mut T) -> U {
     let context: Context = Context::create();
     let exec_engine = compile(&context, source);
-    run::<T,U>(&exec_engine, "main", params)
+    run::<T, U>(&exec_engine, "main", params)
 }
 
-pub fn run<T,U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {
+pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {
     unsafe {
-        let main: JitFunction<MainFunction<T,U>> = exec_engine.get_function(name).unwrap();
+        let main: JitFunction<MainFunction<T, U>> = exec_engine.get_function(name).unwrap();
         let main_t_ptr = &mut *params as *mut _;
         let int_res = main.call(main_t_ptr);
         int_res


### PR DESCRIPTION
To support tests where the main function returns values other than INT, we introduced an extra type parameter U to the compile and run
This has the side effect that the type of the result should now be specified and cannot always be inferred (in fact it can't be inferred in any of the tests)