### PR TITLE
Add a target type to array literals

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -247,7 +247,16 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
                 operator, value, ..
             } => self.generate_unary_expression(operator, value),
             //fallback
-            _ => self.generate_literal(expression),
+            _ => {
+                //Attemt to derive a target type
+                if self.type_hint.is_none() {
+                    if let Some(generator) = self.annotations.get_type(expression, self.index).map(|it|self.morph_to_typed(it.get_type_information())) {
+                        return generator.generate_literal(expression);
+                    }
+                }
+                self.generate_literal(expression)
+
+            },
         }
     }
 

--- a/tests/correctness/initial_values.rs
+++ b/tests/correctness/initial_values.rs
@@ -763,3 +763,25 @@ fn initialization_of_string_variables() {
     ); // QWERT
     assert_eq!(maintype.string3[7..21], [0; 14]); // rest is blank
 }
+
+#[test]
+fn initial_array_value_tests() {
+
+    #[derive(Default)]
+    #[repr(C)]
+    struct Params {
+        arr : [i32; 9],
+    }
+
+    let prog = "
+    FUNCTION main : DINT
+    VAR
+    myArr : ARRAY[0..8] OF DINT := [0,1,2,3,4,5,6,7,8];
+    END_VAR
+    main := myArr[5];
+    END_FUNCTION
+    ";
+    let mut params = Params::default();
+    let res : i32 = compile_and_run(prog.to_string(), &mut params);
+    assert_eq!(5,res);
+}

--- a/tests/correctness/sums.rs
+++ b/tests/correctness/sums.rs
@@ -69,6 +69,7 @@ fn real_division_by_zero() {
     assert!(main.r.is_infinite());
 }
 
+#[test]
 fn order_of_operations_sum() {
     let prog = "
     FUNCTION main : DINT


### PR DESCRIPTION
Added a "target type" to the resolver that could be used to derive
literal types when no other information is available
We currenty use it for array literals on variable initialization where
we grab the type out of the variable data type.

Fixes #297 