### PR TITLE
Constants validation (fb instances not allowed #295, scoped const expressions #292)

### DIFF
--- a/src/codegen/generators/struct_generator.rs
+++ b/src/codegen/generators/struct_generator.rs
@@ -105,8 +105,9 @@ impl<'a, 'b> StructGenerator<'a, 'b> {
         {
             Some(statement) => {
                 //evalute the initializer to a value
+                //TODO we should not resolve here, they should be resolved before!
                 let evaluated_const =
-                    crate::resolver::const_evaluator::evaluate(statement, self.index);
+                    crate::resolver::const_evaluator::evaluate(statement, None, self.index);
                 match evaluated_const {
                     Ok(Some(initializer)) => {
                         //create the appropriate Literal AST-Statement

--- a/src/index.rs
+++ b/src/index.rs
@@ -355,9 +355,9 @@ impl Index {
         initializer_id
             .as_ref()
             .and_then(|it| import_from.remove(it))
-            .map(|(init, target_type)| {
+            .map(|(init, target_type, scope)| {
                 self.get_mut_const_expressions()
-                    .add_constant_expression(init, target_type)
+                    .add_constant_expression(init, target_type, scope)
             })
     }
 
@@ -372,9 +372,12 @@ impl Index {
             TypeSize::LiteralInteger(_) => type_size.clone(),
             TypeSize::ConstExpression(id) => import_from
                 .remove(id)
-                .map(|(expr, target_type)| {
-                    self.get_mut_const_expressions()
-                        .add_constant_expression(expr, target_type)
+                .map(|(expr, target_type, scope)| {
+                    self.get_mut_const_expressions().add_constant_expression(
+                        expr,
+                        target_type,
+                        scope,
+                    )
                 })
                 .map(TypeSize::from_expression)
                 .unwrap(),

--- a/src/index.rs
+++ b/src/index.rs
@@ -95,7 +95,7 @@ pub enum DataTypeType {
     AliasType,     // a Custom-Alias-dataType
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum ImplementationType {
     Program,
     Function,
@@ -105,7 +105,7 @@ pub enum ImplementationType {
     Method,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ImplementationIndexEntry {
     call_name: String,
     type_name: String,

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -184,9 +184,7 @@ fn fb_methods_are_indexed() {
         .unwrap()
         .get_type_information();
     if let crate::typesystem::DataTypeInformation::Struct {
-        name,
-        member_names,
-        varargs: _,
+        name, member_names, ..
     } = info
     {
         assert_eq!("myFuncBlock.foo_interface", name);
@@ -216,9 +214,7 @@ fn class_methods_are_indexed() {
         .unwrap()
         .get_type_information();
     if let crate::typesystem::DataTypeInformation::Struct {
-        name,
-        member_names,
-        varargs: _,
+        name, member_names, ..
     } = info
     {
         assert_eq!("myClass.foo_interface", name);

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -86,7 +86,11 @@ pub fn visit_pou(index: &mut Index, pou: &Pou) {
             };
             let initial_value = index
                 .get_mut_const_expressions()
-                .maybe_add_constant_expression(var.initializer.clone(), type_name.as_str());
+                .maybe_add_constant_expression(
+                    var.initializer.clone(),
+                    type_name.as_str(),
+                    Some(pou.name.clone()),
+                );
 
             index.register_member_variable(
                 &MemberInfo {
@@ -179,7 +183,7 @@ fn visit_global_var_block(index: &mut Index, block: &VariableBlock) {
         let target_type = var.data_type.get_name().unwrap_or_default();
         let initializer = index
             .get_mut_const_expressions()
-            .maybe_add_constant_expression(var.initializer.clone(), target_type);
+            .maybe_add_constant_expression(var.initializer.clone(), target_type, None);
         index.register_global_variable(
             &var.name,
             var.data_type.get_name().unwrap(),
@@ -224,6 +228,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 .maybe_add_constant_expression(
                     type_declatation.initializer.clone(),
                     type_name.as_str(),
+                    None,
                 );
             index.register_type(name.as_ref().unwrap(), init, information);
             for (count, var) in variables.iter().enumerate() {
@@ -242,7 +247,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 let member_type = var.data_type.get_name().unwrap();
                 let init = index
                     .get_mut_const_expressions()
-                    .maybe_add_constant_expression(var.initializer.clone(), member_type);
+                    .maybe_add_constant_expression(var.initializer.clone(), member_type, None);
                 index.register_member_variable(
                     &MemberInfo {
                         container_name: struct_name,
@@ -270,6 +275,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 .maybe_add_constant_expression(
                     type_declatation.initializer.clone(),
                     enum_name.as_str(),
+                    None,
                 );
             index.register_type(enum_name.as_str(), init, information);
 
@@ -281,6 +287,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                         id: 0,
                     },
                     typesystem::INT_TYPE.to_string(),
+                    None,
                 );
                 index.register_enum_element(
                     v,
@@ -315,6 +322,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 .maybe_add_constant_expression(
                     type_declatation.initializer.clone(),
                     name.as_ref().unwrap(),
+                    None,
                 );
             index.register_type(name.as_ref().unwrap(), init, information)
         }
@@ -334,12 +342,14 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                                 constants.add_constant_expression(
                                     *start.clone(),
                                     typesystem::INT_TYPE.to_string(),
+                                    None,
                                 ),
                             ),
                             end_offset: TypeSize::from_expression(
                                 constants.add_constant_expression(
                                     *end.clone(),
                                     typesystem::INT_TYPE.to_string(),
+                                    None,
                                 ),
                             ),
                         })
@@ -364,6 +374,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 .maybe_add_constant_expression(
                     type_declatation.initializer.clone(),
                     name.as_ref().unwrap(),
+                    None,
                 );
             index.register_type(name.as_ref().unwrap(), init, information)
         }
@@ -384,6 +395,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 .maybe_add_constant_expression(
                     type_declatation.initializer.clone(),
                     name.as_ref().unwrap(),
+                    None,
                 );
             index.register_type(name.as_ref().unwrap(), init, information)
         }
@@ -418,9 +430,11 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                     };
 
                     TypeSize::from_expression(
-                        index
-                            .get_mut_const_expressions()
-                            .add_constant_expression(len_plus_1, type_name.clone()),
+                        index.get_mut_const_expressions().add_constant_expression(
+                            len_plus_1,
+                            type_name.clone(),
+                            None,
+                        ),
                     )
                 }
                 None => TypeSize::from_literal(DEFAULT_STRING_LEN + 1),
@@ -428,7 +442,11 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
             let information = DataTypeInformation::String { size, encoding };
             let init = index
                 .get_mut_const_expressions()
-                .maybe_add_constant_expression(type_declatation.initializer.clone(), type_name);
+                .maybe_add_constant_expression(
+                    type_declatation.initializer.clone(),
+                    type_name,
+                    None,
+                );
             index.register_type(name.as_ref().unwrap(), init, information)
         }
         DataType::VarArgs { .. } => {} //Varargs are not indexed

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -129,6 +129,7 @@ pub fn visit_pou(index: &mut Index, pou: &Pou) {
             name: interface_name,
             member_names,
             varargs,
+            source: StructSource::Pou(pou.pou_type.clone()),
         },
     );
 }
@@ -215,6 +216,7 @@ fn visit_data_type(index: &mut Index, type_declatation: &UserTypeDeclaration) {
                 name: type_name.clone(),
                 member_names,
                 varargs: None,
+                source: StructSource::OriginalDeclaration,
             };
 
             let init = index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub enum ErrNo {
     //variable related
     var__unresolved_constant,
     var__invalid_constant_block,
+    var__invalid_constant,
 
     //reference related
     reference__unresolved,
@@ -282,6 +283,14 @@ impl Diagnostic {
             message: "This variable block does not support the CONSTANT modifier".to_string(),
             range: location,
             err_no: ErrNo::var__invalid_constant_block,
+        }
+    }
+
+    pub fn invalid_constant(constant_name: &str, location: SourceRange) -> Diagnostic {
+        Diagnostic::SyntaxError {
+            message: format!("Invalid constant {:} - Functionblock- and Class-instances cannot be delcared constant", constant_name),
+            range: location,
+            err_no: ErrNo::var__invalid_constant,
         }
     }
 

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -2,7 +2,7 @@
 use std::{mem::size_of, ops::Range};
 
 use crate::{
-    ast::AstStatement,
+    ast::{AstStatement, PouType},
     index::{const_expressions::ConstId, Index},
 };
 
@@ -141,12 +141,20 @@ impl TypeSize {
     }
 }
 
+/// indicates where this Struct origins from.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StructSource {
+    OriginalDeclaration,
+    Pou(PouType),
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataTypeInformation {
     Struct {
         name: String,
         member_names: Vec<String>,
         varargs: Option<VarArgs>,
+        source: StructSource,
     },
     Array {
         name: String,

--- a/src/validation/variable_validator.rs
+++ b/src/validation/variable_validator.rs
@@ -1,6 +1,12 @@
+use inkwell::types::StructType;
+
 use crate::{
-    ast::{DataType, DataTypeDeclaration, SourceRange, Variable, VariableBlock, VariableBlockType},
-    index::const_expressions::ConstExpression,
+    ast::{
+        DataType, DataTypeDeclaration, PouType, SourceRange, Variable, VariableBlock,
+        VariableBlockType,
+    },
+    index::{const_expressions::ConstExpression, ImplementationType, Index},
+    typesystem::{DataTypeInformation, StructSource},
     Diagnostic,
 };
 
@@ -41,6 +47,14 @@ impl VariableValidator {
             .and_then(|qualifier| context.index.find_member(qualifier, variable.name.as_str()))
             .or_else(|| context.index.find_global_variable(variable.name.as_str()))
         {
+            println!(
+                "validating: {:} : {:#?}",
+                v_entry.get_name(),
+                context
+                    .index
+                    .find_effective_type_by_name(v_entry.get_type_name())
+            );
+
             match v_entry.initial_value.and_then(|initial_id| {
                 context
                     .index
@@ -70,6 +84,16 @@ impl VariableValidator {
                 }
                 _ => {}
             }
+
+            //check if we declared a constant fb-instance or class-instance
+            if v_entry.is_constant()
+                && data_type_is_fb_or_class_instance(v_entry.get_type_name(), context.index)
+            {
+                self.diagnostics.push(Diagnostic::invalid_constant(
+                    v_entry.get_name(),
+                    variable.location.clone(),
+                ));
+            }
         }
     }
 
@@ -91,6 +115,48 @@ impl VariableValidator {
             }
             _ => {}
         }
+    }
+}
+
+/// returns whether this data_type is a function block, a class or an array/pointer of/to these
+fn data_type_is_fb_or_class_instance(type_name: &str, index: &Index) -> bool {
+    let data_type = index.find_effective_type_by_name(type_name).map_or_else(
+        || index.get_void_type().get_type_information(),
+        crate::typesystem::DataType::get_type_information,
+    );
+
+    if let DataTypeInformation::Struct {
+        source: StructSource::Pou(PouType::FunctionBlock) | StructSource::Pou(PouType::Class),
+        ..
+    } = data_type
+    {
+        return true;
+    }
+
+    match data_type {
+        DataTypeInformation::Struct {
+            member_names, name, ..
+        } =>
+        //see if any member is fb or class intance
+        {
+            member_names.iter().any(|member_name| {
+                index
+                    .find_member(name.as_str(), member_name.as_str())
+                    .map_or(false, |v| {
+                        data_type_is_fb_or_class_instance(v.get_type_name(), index)
+                    })
+            })
+        }
+        DataTypeInformation::Array {
+            inner_type_name, ..
+        } => data_type_is_fb_or_class_instance(inner_type_name.as_str(), index),
+        DataTypeInformation::Pointer {
+            inner_type_name, ..
+        } => data_type_is_fb_or_class_instance(inner_type_name.as_str(), index),
+        DataTypeInformation::Alias {
+            referenced_type, ..
+        } => data_type_is_fb_or_class_instance(referenced_type.as_str(), index),
+        _ => false,
     }
 }
 

--- a/src/validation/variable_validator.rs
+++ b/src/validation/variable_validator.rs
@@ -1,11 +1,9 @@
-use inkwell::types::StructType;
-
 use crate::{
     ast::{
         DataType, DataTypeDeclaration, PouType, SourceRange, Variable, VariableBlock,
         VariableBlockType,
     },
-    index::{const_expressions::ConstExpression, ImplementationType, Index},
+    index::{const_expressions::ConstExpression, Index},
     typesystem::{DataTypeInformation, StructSource},
     Diagnostic,
 };
@@ -68,7 +66,7 @@ impl VariableValidator {
                         statement.get_location(),
                     ));
                 }
-                Some(ConstExpression::Unresolved(statement)) => {
+                Some(ConstExpression::Unresolved { statement, .. }) => {
                     self.diagnostics.push(Diagnostic::unresolved_constant(
                         variable.name.as_str(),
                         None,


### PR DESCRIPTION
1. fb-instances and class-instances cannot be declared
as constants.

>    the implementation does not allow to declare a const
>    of type FB or Class, an array of FBs or Classes
>    or a struct that contains a field of type FB or
>    Class.
>    
>    Furthermore the DataTypeInformation::Struct now contains
>    a new field: 'source' that indicates where this struct
>    comes from. It is either an original Declaration
>    (TYPE x : STRUCT ... END_TYPE) or it was generated
>    from a POU(PouType). With this field it is now very
>    easy to see what a DataType offers (is it an FB or Class,
>    can I call it, etc.)
>    
>    closes #295

2. add scope to unresolved const expressions
>     the additional scope parameter in const_evaluator::evaluate(...)
>     helps the evaluator to distinguish between global constants and
>     POU-local ones. When resolving const expressions the given
>     scope will be used to resolve references.
>     
>     therefore every ConstExpression holds an optional scope when it
>     is registered (see enum ConstExpression).
>     
>     closes #292